### PR TITLE
Provider routing display fix + non-fatal user upsert + better /api/conversations errors

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -80,25 +80,45 @@ async function ensureSessionUserInDatabase(req: any) {
 
   if (!sessionUserId || !sessionUser) return;
 
-  await db
-    .insert(users)
-    .values({
-      id: sessionUserId,
-      email: sessionUser.email || null,
-      firstName: sessionUser.firstName || null,
-      lastName: sessionUser.lastName || null,
-      profileImageUrl: sessionUser.profileImageUrl || null,
-    })
-    .onConflictDoUpdate({
-      target: users.id,
-      set: {
+  // The users table has a unique constraint on email; onConflictDoUpdate
+  // here only keys on id, so a row colliding on email (different id, same
+  // email) would throw a unique violation and crash any caller. Wrap in
+  // try/catch so this never breaks /api/conversations creation — the
+  // foreign key only requires the user row exists, not that we just
+  // freshly upserted it. Log the failure so we still see when it happens.
+  try {
+    await db
+      .insert(users)
+      .values({
+        id: sessionUserId,
         email: sessionUser.email || null,
         firstName: sessionUser.firstName || null,
         lastName: sessionUser.lastName || null,
         profileImageUrl: sessionUser.profileImageUrl || null,
-        updatedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: users.id,
+        set: {
+          email: sessionUser.email || null,
+          firstName: sessionUser.firstName || null,
+          lastName: sessionUser.lastName || null,
+          profileImageUrl: sessionUser.profileImageUrl || null,
+          updatedAt: new Date(),
+        },
+      });
+  } catch (err: any) {
+    void logRuntimeEvent({
+      level: "warn",
+      source: "server",
+      event: "user.upsert.failed",
+      detail: err?.message || String(err),
+      context: {
+        userId: sessionUserId,
+        email: sessionUser.email || null,
+        errorKind: err?.constructor?.name,
       },
     });
+  }
 }
 
 async function requireConversation(req: any, res: Response) {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -212,9 +212,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
         console.warn("[Conversations] Session creation failed (non-fatal):", sessionError);
       }
       res.json(conversation);
-    } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: "Failed to create conversation" });
+    } catch (err: any) {
+      const detail = err?.message || String(err);
+      console.error("[POST /api/conversations] failed:", err);
+      await logRuntimeEvent({
+        level: "error",
+        source: "server",
+        event: "conversation.create.failed",
+        detail,
+        context: {
+          userId: req.user?.claims?.sub,
+          mode: req.body?.mode,
+          errorKind: err?.constructor?.name,
+          stack: err?.stack?.split("\n").slice(0, 4).join(" | "),
+        },
+      });
+      res.status(500).json({ error: detail || "Failed to create conversation" });
     }
   });
 
@@ -807,9 +820,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const config = getProviderRuntimeConfig();
       const target = getResolvedTargetName({ lane: "chat" });
       const provider = getActiveProviderName({ lane: "chat" });
-      const ollamaUrl = config.ollama.baseUrl;
-      const remoteUrl = config.clawTemp.baseUrl;
-      const probeUrl = provider === "claw-temp" ? remoteUrl : ollamaUrl;
+      // probeUrl must reflect the ACTIVE provider's base URL, not always
+      // the Ollama URL — otherwise the admin Provider Routing card shows
+      // "localhost:11434" even when chat actually goes to Lightning/OpenAI.
+      const probeUrl =
+        provider === "openai"
+          ? config.openai.baseUrl
+          : provider === "claude"
+            ? config.claude.baseUrl
+            : provider === "claw-temp"
+              ? config.clawTemp.baseUrl
+              : config.ollama.baseUrl;
 
       const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/i.test(probeUrl);
       const targetHost = (() => {


### PR DESCRIPTION
Two fixes for issues visible in the live deploy:

## 1. Provider Routing card showing "localhost:11434" / LOCAL badge

The admin Overview's Provider Routing card was misleadingly showing the Ollama URL with a LOCAL badge even when the active provider was OpenAI/Lightning. Actual chat calls were always going to the right place — the bug was in `/api/system/runtime` where `probeUrl` was hardcoded to `config.ollama.baseUrl` regardless of which provider was active. The display fields (target_url, is_local, location_label) all derived from probeUrl, so they all showed Ollama info.

Fix: probeUrl now follows the active provider's own baseUrl.

## 2. POST /api/conversations 500s with no error detail

The handler caught exceptions, console.error'd them, and returned a generic "Failed to create conversation" string. The runtime log only captured the HTTP response status — never the actual exception. Logs tab showed `POST /api/conversations -> 500` with no clue why.

Fix: error catch now writes a structured `conversation.create.failed` runtime log entry with exception message, errorKind (constructor name), first 4 lines of stack, and the request's userId + mode. Returns the real message in the response body so the chat UI also shows it.

## 3. ensureSessionUserInDatabase made non-fatal (probable root-cause repair)

The users table has a UNIQUE constraint on email but `onConflictDoUpdate` keys only on id. A row colliding on email (different id, same email) throws a unique-violation that bubbles all the way out of /api/conversations as a 500 — likely the actual bug behind the symptom above.

Fix: wrap the upsert in try/catch. The foreign key on `conversations.userId` only requires the user row exists, not that we just refreshed it, so this never breaks conversation creation. Failures log `user.upsert.failed` with context so we still see when it happens.

If the email-collision theory is right, this fixes chat outright. If not, the new `conversation.create.failed` logging from #2 will surface the real reason on the next failure.

## Commits

- 07927f3 Fix Provider Routing showing localhost + log real /api/conversations errors
- 6bbd429 Make ensureSessionUserInDatabase non-fatal; log upsert failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_