### PR TITLE
Fix /api/flows/runs 404 (route order) + chat composer textarea squeeze

### DIFF
--- a/client/src/components/chat/ChatComposer.tsx
+++ b/client/src/components/chat/ChatComposer.tsx
@@ -229,7 +229,7 @@ export default function ChatComposer({
           <button
             type="button"
             onClick={() => setShowLanePicker((v) => !v)}
-            className={`flex h-9 items-center gap-1.5 rounded-xl border border-white/10 px-3 text-xs font-medium transition-colors ${
+            className={`flex h-9 items-center gap-1.5 rounded-xl border border-white/10 px-2.5 text-xs font-medium transition-colors max-w-[40%] ${
               currentMode === "agent"
                 ? "bg-purple-500/15 text-purple-100 hover:bg-purple-500/25"
                 : "bg-white/5 text-foreground hover:bg-white/10"
@@ -239,12 +239,12 @@ export default function ChatComposer({
             data-testid="composer-lane-chip"
           >
             {currentMode === "agent" && (
-              <img src={zLogoPath} alt="" className="h-3 w-3" />
+              <img src={zLogoPath} alt="" className="h-3 w-3 shrink-0" />
             )}
-            <span className="whitespace-nowrap">
-              {currentMode === "agent" ? `Agent · ${activeLane.label}` : "Chat"}
+            <span className="truncate">
+              {currentMode === "agent" ? activeLane.label : "Chat"}
             </span>
-            <ChevronDown size={12} className="opacity-70" />
+            <ChevronDown size={12} className="opacity-70 shrink-0" />
           </button>
 
           {showLanePicker && (
@@ -317,7 +317,7 @@ export default function ChatComposer({
         </div>
 
         {/* Textarea + inline dictate mic */}
-        <div className="flex-1 relative">
+        <div className="flex-1 relative min-w-0">
           <Textarea
             ref={textareaRef}
             value={value}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1223,6 +1223,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
     });
   });
 
+  // ⚠️ /api/flows/runs and /api/flows/runs/:runId MUST be registered
+  // before /api/flows/:id, otherwise Express matches "runs" as the :id
+  // parameter and the runs list 404s.
+  app.get("/api/flows/runs", isAuthenticated, async (req: any, res) => {
+    const runs = await FlowStore.listRuns({
+      userId: req.user?.claims?.sub,
+      limit: 50,
+    });
+    res.json({ runs });
+  });
+
+  app.get("/api/flows/runs/:runId", isAuthenticated, async (req, res) => {
+    const run = await FlowStore.getRun(req.params.runId);
+    if (!run) return res.status(404).json({ error: "Not found" });
+    res.json(run);
+  });
+
   app.get("/api/flows/:id", isAuthenticated, async (req, res) => {
     const flow = await FlowStore.getDefinition(req.params.id);
     if (!flow || flow.status !== "published") {
@@ -1242,20 +1259,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
       conversationId: req.body?.conversationId,
       context: req.body?.context,
     });
-    res.json(run);
-  });
-
-  app.get("/api/flows/runs", isAuthenticated, async (req: any, res) => {
-    const runs = await FlowStore.listRuns({
-      userId: req.user?.claims?.sub,
-      limit: 50,
-    });
-    res.json({ runs });
-  });
-
-  app.get("/api/flows/runs/:runId", isAuthenticated, async (req, res) => {
-    const run = await FlowStore.getRun(req.params.runId);
-    if (!run) return res.status(404).json({ error: "Not found" });
     res.json(run);
   });
 


### PR DESCRIPTION
## Two surgical fixes

### 1. `GET /api/flows/runs -> 404`

`/api/flows/:id` was registered before `/api/flows/runs`, so Express matched `runs` as the `:id` parameter and `getDefinition("runs")` returned 404. The user-facing `/runs` page couldn't load.

**Fix**: move `/api/flows/runs` and `/api/flows/runs/:runId` registrations *before* `/api/flows/:id`. Added an inline comment so future edits don't accidentally re-introduce the shadowing.

### 2. Chat composer chip squeezed the textarea

When in Agent mode with a long lane label (e.g. "Agent · Operations"), the chip consumed enough row width that the `flex-1` textarea collapsed below its placeholder's natural width — "Message Zed" rendered vertically letter-by-letter.

**Fix**:
- Drop "Agent · " prefix from the chip (the Z logo already signals agent mode)
- `max-w-[40%]` + `truncate` on the chip
- `min-w-0` on the textarea container so flex-shrink actually engages

## Commit
- `6d6b5de` Fix /api/flows/runs 404 (route order) + chat composer chip squeeze

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_