### PR TITLE
Lane chip empty-state fix + expose postgres error code in upsert log

### DIFF
--- a/client/src/components/chat/ChatComposer.tsx
+++ b/client/src/components/chat/ChatComposer.tsx
@@ -229,7 +229,7 @@ export default function ChatComposer({
           <button
             type="button"
             onClick={() => setShowLanePicker((v) => !v)}
-            className={`flex h-9 items-center gap-1.5 rounded-xl border border-white/10 px-2.5 text-xs font-medium transition-colors max-w-[40%] ${
+            className={`flex h-9 items-center gap-1.5 rounded-xl border border-white/10 px-2.5 text-xs font-medium transition-colors max-w-[140px] ${
               currentMode === "agent"
                 ? "bg-purple-500/15 text-purple-100 hover:bg-purple-500/25"
                 : "bg-white/5 text-foreground hover:bg-white/10"
@@ -241,7 +241,7 @@ export default function ChatComposer({
             {currentMode === "agent" && (
               <img src={zLogoPath} alt="" className="h-3 w-3 shrink-0" />
             )}
-            <span className="truncate">
+            <span className="truncate min-w-0">
               {currentMode === "agent" ? activeLane.label : "Chat"}
             </span>
             <ChevronDown size={12} className="opacity-70 shrink-0" />

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -118,15 +118,23 @@ async function ensureSessionUserInDatabase(req: any) {
         },
       });
   } catch (err: any) {
+    // DrizzleQueryError wraps the real postgres error in .cause. Pull it
+    // out so we see the actual code (e.g. 23505 = unique_violation) and
+    // constraint name instead of just the SQL text.
+    const cause: any = err?.cause || err?.original || err;
     void logRuntimeEvent({
       level: "warn",
       source: "server",
       event: "user.upsert.failed",
-      detail: err?.message || String(err),
+      detail: cause?.message || err?.message || String(err),
       context: {
         userId: sessionUserId,
         email: sessionUser.email || claims.email || null,
         errorKind: err?.constructor?.name,
+        pgCode: cause?.code,
+        pgConstraint: cause?.constraint,
+        pgDetail: cause?.detail,
+        pgTable: cause?.table,
       },
     });
   }


### PR DESCRIPTION
## Two small follow-ups

### 1. Lane chip rendering empty in Chat mode

The previous `max-w-[40%]` was too aggressive on narrow iPhone widths — the chip rendered with only the chevron, no "Chat" label.

**Fix**: switch to `max-w-[140px]` (px-based cap) and add `min-w-0` to the inner span so truncate engages predictably.

### 2. `user.upsert.failed` log was missing the actual DB error code

DrizzleQueryError's `.message` is just the SQL text. The real postgres error code, constraint, table all live on `.cause`. Without those we can't tell if the failure is a unique violation, a foreign key issue, a check constraint, etc.

**Fix**: log now includes `pgCode`, `pgConstraint`, `pgDetail`, `pgTable` from `err.cause`. Next failure will show e.g. `pgCode: "23505"` + `pgConstraint: "users_email_unique"` — definitive diagnosis.

## Commit
- `71f873f` Fix lane chip empty in chat mode + expose postgres error code in user.upsert.failed

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_