### PR TITLE
Flow execution engine + approve/reject controls + avatar tooltip fix

### DIFF
--- a/client/src/components/chat/ChatSidebarUserCard.tsx
+++ b/client/src/components/chat/ChatSidebarUserCard.tsx
@@ -64,7 +64,12 @@ export default function ChatSidebarUserCard({
             )}
           </div>
 
-          <div className="absolute -top-8 left-1/2 -translate-x-1/2 bg-black text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
+          {/* Anchor the tooltip to the avatar's left edge so it grows
+              rightward into the sidebar rather than getting clipped on
+              the left by the sidebar's overflow boundary. Hidden on
+              mobile where hover isn't meaningful and the camera badge
+              already signals upload. */}
+          <div className="hidden md:block absolute -top-8 left-0 bg-black text-white text-xs px-2 py-1 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
             Click to upload photo
           </div>
         </div>

--- a/client/src/pages/runs.tsx
+++ b/client/src/pages/runs.tsx
@@ -10,6 +10,9 @@ import {
   Workflow,
 } from "lucide-react";
 
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -46,6 +49,16 @@ const STAGE_TONE: Record<FlowStageRunStatus, string> = {
   skipped: "text-muted-foreground/60",
   failed: "text-red-300",
 };
+
+/** Convert "s1-opportunity-detection" → "Opportunity Detection". */
+function prettifyStageId(id: string): string {
+  return id
+    .replace(/^s\d+-/, "")
+    .split("-")
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ")
+    .trim();
+}
 
 export function RunsListPage() {
   const [, navigate] = useLocation();
@@ -147,6 +160,7 @@ export function RunDetailPage() {
   const [run, setRun] = useState<FlowRun | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actionPending, setActionPending] = useState<"approve" | "reject" | null>(null);
 
   async function fetchRun() {
     if (!runId) return;
@@ -163,10 +177,64 @@ export function RunDetailPage() {
     }
   }
 
+  async function approve() {
+    if (!runId) return;
+    setActionPending("approve");
+    try {
+      const res = await fetch(`/api/flows/runs/${runId}/approve`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await fetchRun();
+    } catch (e: any) {
+      setError(e?.message || "Failed to approve");
+    } finally {
+      setActionPending(null);
+    }
+  }
+
+  async function reject() {
+    if (!runId) return;
+    const reason = window.prompt("Reason for rejecting? (optional)") ?? "";
+    setActionPending("reject");
+    try {
+      const res = await fetch(`/api/flows/runs/${runId}/reject`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ reason }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      await fetchRun();
+    } catch (e: any) {
+      setError(e?.message || "Failed to reject");
+    } finally {
+      setActionPending(null);
+    }
+  }
+
   useEffect(() => {
     void fetchRun();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId]);
+
+  // Poll while the run is still progressing
+  useEffect(() => {
+    if (!run) return;
+    const live =
+      run.status === "queued" ||
+      run.status === "running" ||
+      run.status === "awaiting_approval";
+    if (!live) return;
+    const interval = window.setInterval(() => {
+      void fetchRun();
+    }, 3000);
+    return () => window.clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run?.status]);
 
   return (
     <div className="min-h-screen bg-black text-white">
@@ -230,20 +298,55 @@ export function RunDetailPage() {
               <p className="mb-2 text-xs uppercase tracking-[0.18em] text-muted-foreground">
                 Stages
               </p>
+              {run.status === "awaiting_approval" && (
+                <div className="rounded-xl border border-purple-500/30 bg-purple-500/5 p-3 space-y-2">
+                  <p className="text-sm font-medium text-purple-200">
+                    This stage requires your approval before the next stage can run.
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={approve}
+                      disabled={actionPending !== null}
+                      className="flex-1 bg-emerald-600 hover:bg-emerald-700 text-white"
+                    >
+                      {actionPending === "approve" ? "Approving…" : "Approve & continue"}
+                    </Button>
+                    <Button
+                      onClick={reject}
+                      disabled={actionPending !== null}
+                      variant="outline"
+                      className="zed-glass border-red-500/40 text-red-200"
+                    >
+                      {actionPending === "reject" ? "Rejecting…" : "Reject"}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
               <div className="space-y-2">
                 {run.stageRuns.map((sr, idx) => {
                   const Icon = STAGE_ICON[sr.status];
                   const tone = STAGE_TONE[sr.status];
+                  const stageName = prettifyStageId(sr.stageId);
+                  const output =
+                    typeof sr.output === "string"
+                      ? sr.output
+                      : sr.output
+                        ? JSON.stringify(sr.output, null, 2)
+                        : null;
                   return (
                     <Card key={sr.stageId} className="zed-glass border-white/10">
-                      <CardContent className="p-3 space-y-1">
+                      <CardContent className="p-3 space-y-1.5">
                         <div className="flex items-center gap-2">
                           <span className="font-mono text-[10px] text-muted-foreground">
                             {String(idx + 1).padStart(2, "0")}
                           </span>
-                          <Icon size={13} className={`shrink-0 ${tone}`} />
+                          <Icon
+                            size={13}
+                            className={`shrink-0 ${tone} ${sr.status === "running" ? "animate-spin" : ""}`}
+                          />
                           <span className={`text-sm font-medium flex-1 truncate ${tone}`}>
-                            {sr.stageId}
+                            {stageName}
                           </span>
                           <Badge
                             variant="secondary"
@@ -259,6 +362,18 @@ export function RunDetailPage() {
                         )}
                         {sr.error && (
                           <p className="text-[11px] text-red-300 leading-5">{sr.error}</p>
+                        )}
+                        {output && sr.status === "completed" && (
+                          <details className="pt-1">
+                            <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-muted-foreground hover:text-foreground">
+                              View output
+                            </summary>
+                            <div className="mt-2 rounded-lg border border-white/10 bg-black/30 p-3 text-xs leading-6 zed-markdown">
+                              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                                {output}
+                              </ReactMarkdown>
+                            </div>
+                          </details>
                         )}
                       </CardContent>
                     </Card>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,6 +22,11 @@ import { getFirewallIntegrationStatus } from "./services/FirewallIntegrationServ
 import { checkGitHubIntegrationStatus, getGitHubRepoReadout } from "./services/GitHubIntegrationService";
 import { getRecentRuntimeEvents, logRuntimeEvent } from "./services/RuntimeLogger";
 import { FlowStore } from "./services/FlowStore";
+import {
+  executeFlowRun,
+  approveCurrentStage,
+  rejectCurrentStage,
+} from "./services/flow/FlowExecutor";
 import { registerExecutionRoutes } from "./services/execution/registerExecutionRoutes";
 import { registerIntakeRoutes } from "./services/intake/registerIntakeRoutes";
 import fs from "fs/promises";
@@ -1267,7 +1272,30 @@ export async function registerRoutes(app: Express): Promise<Server> {
       conversationId: req.body?.conversationId,
       context: req.body?.context,
     });
+    // Kick off async execution. Don't block the response — the UI will
+    // poll the run detail endpoint to observe progress.
+    void executeFlowRun(run.id);
     res.json(run);
+  });
+
+  app.post("/api/flows/runs/:runId/approve", isAuthenticated, async (req, res) => {
+    const run = await approveCurrentStage(req.params.runId, req.body?.note);
+    if (!run) return res.status(404).json({ error: "Run not found or not pending approval" });
+    res.json(run);
+  });
+
+  app.post("/api/flows/runs/:runId/reject", isAuthenticated, async (req, res) => {
+    const run = await rejectCurrentStage(req.params.runId, req.body?.reason);
+    if (!run) return res.status(404).json({ error: "Run not found or not pending approval" });
+    res.json(run);
+  });
+
+  app.post("/api/flows/runs/:runId/resume", isAuthenticated, async (req, res) => {
+    // Manual nudge if a run got stuck (e.g. process restarted mid-execution).
+    const run = await FlowStore.getRun(req.params.runId);
+    if (!run) return res.status(404).json({ error: "Not found" });
+    void executeFlowRun(req.params.runId);
+    res.json({ ok: true, runId: req.params.runId });
   });
 
   app.get("/api/admin/env-validate", isAdmin, async (_req, res) => {

--- a/server/services/flow/FlowExecutor.ts
+++ b/server/services/flow/FlowExecutor.ts
@@ -1,0 +1,317 @@
+import { executeProviderChat } from "../../core/providers/provider-executor";
+import { logRuntimeEvent } from "../RuntimeLogger";
+import { FlowStore } from "../FlowStore";
+import type {
+  FlowAgentKey,
+  FlowDefinition,
+  FlowRun,
+  FlowStage,
+  FlowStageRun,
+} from "../../../shared/flow-types";
+
+/**
+ * Lane key used when calling the model for a given agent. Flow stages
+ * already have an assignedAgent that matches our existing per-lane
+ * routing (chat / manager / operations / research / business / finance
+ * via MODEL_<LANE> env vars).
+ */
+function laneForAgent(agent: FlowAgentKey | undefined): string {
+  if (!agent) return "manager";
+  switch (agent) {
+    case "operations":
+    case "research":
+    case "business":
+    case "finance":
+    case "manager":
+      return agent;
+    // No dedicated lanes for these — bucket them under the most
+    // semantically-aligned existing lane.
+    case "content":
+      return "operations";
+    case "security":
+      return "manager";
+    default:
+      return "manager";
+  }
+}
+
+const SYSTEM_PROMPTS: Record<FlowAgentKey, string> = {
+  operations:
+    "You are the Operations Agent inside the ZED flow execution engine. " +
+    "You are responsible for scheduling, routing, task assignment, and structured operational output. " +
+    "Be concrete and decisive. Produce checklists, schedules, and assignments — not paragraphs.",
+  research:
+    "You are the Research / Intelligence Agent. " +
+    "Synthesize information into clear findings. Cite sources where applicable. " +
+    "Identify what's known, what's uncertain, and what to verify next.",
+  business:
+    "You are the Business Manager Agent. " +
+    "Focus on commerce, strategy, partnerships, and prioritization by impact. " +
+    "Use the 80/20 lens — call out the highest-leverage action explicitly.",
+  finance:
+    "You are the Finance Agent. " +
+    "Be precise with numbers, conservative on risk, and explicit about assumptions. " +
+    "Recommend cash, savings, credit, and investment actions based on actual ratios.",
+  content:
+    "You are the Content Agent. " +
+    "Produce written deliverables: drafts, outlines, social posts, email copy. " +
+    "Write in the brand voice the flow context establishes. Mark sections that need review.",
+  security:
+    "You are the Security Agent. " +
+    "Apply incident-response discipline: classify severity, contain risk, identify root cause, " +
+    "and produce a postmortem. Never weaken a guard to fix a symptom.",
+  manager:
+    "You are the Manager Agent. Coordinate across other agents and produce a synthesizing summary.",
+};
+
+/**
+ * Build the user-facing prompt for one stage. The system prompt comes
+ * from SYSTEM_PROMPTS[stage.assignedAgent]; this returns the body.
+ */
+function buildStagePrompt(opts: {
+  flow: FlowDefinition;
+  stage: FlowStage;
+  priorOutputs: Record<string, unknown>;
+  initialContext: Record<string, unknown>;
+}): string {
+  const { flow, stage, priorOutputs, initialContext } = opts;
+  const stepLines = stage.steps
+    .sort((a, b) => a.order - b.order)
+    .map((s, i) => `${i + 1}. ${s.label}${s.detail ? ` — ${s.detail}` : ""}`)
+    .join("\n");
+
+  const priorBlock = Object.entries(priorOutputs)
+    .map(([stageName, output]) => {
+      const text =
+        typeof output === "string" ? output : JSON.stringify(output, null, 2);
+      return `### From earlier stage "${stageName}"\n${text}`;
+    })
+    .join("\n\n");
+
+  const initBlock = Object.keys(initialContext).length
+    ? `### Initial context from the user\n${JSON.stringify(initialContext, null, 2)}`
+    : "";
+
+  return [
+    `## Flow: ${flow.name}`,
+    `## Stage: ${stage.name}`,
+    flow.purpose ? `Flow purpose: ${flow.purpose}` : "",
+    stage.description ? `Stage goal: ${stage.description}` : "",
+    "",
+    `Steps to address:\n${stepLines}`,
+    "",
+    initBlock,
+    priorBlock,
+    "",
+    "Produce a concrete, structured output for THIS stage only. Use markdown. " +
+      "Be decisive. Where the next stage will need something specific from you, " +
+      "make sure it's clearly labeled in your response.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Set of run IDs currently executing in-process. Prevents double-kickoff
+ * if the same run gets advanced twice in quick succession (e.g. user
+ * double-taps Approve before the UI updates).
+ */
+const inFlight = new Set<string>();
+
+/**
+ * Drive a FlowRun forward from its current stage until either:
+ *  - it completes,
+ *  - it hits a stage that requires approval (status = awaiting_approval),
+ *  - a stage fails (status = failed).
+ *
+ * Safe to call repeatedly — re-entry on the same runId is a no-op while
+ * the previous invocation is still running.
+ */
+export async function executeFlowRun(runId: string): Promise<void> {
+  if (inFlight.has(runId)) return;
+  inFlight.add(runId);
+  try {
+    let run = await FlowStore.getRun(runId);
+    if (!run) return;
+    const flow = await FlowStore.getDefinition(run.flowId);
+    if (!flow) {
+      await FlowStore.updateRun(runId, {
+        status: "failed",
+      });
+      return;
+    }
+
+    if (run.status === "completed" || run.status === "failed" || run.status === "cancelled") {
+      return;
+    }
+
+    // Mark running on first entry from queued.
+    if (run.status === "queued") {
+      run = (await FlowStore.updateRun(runId, { status: "running" })) || run;
+    }
+
+    const orderedStages = [...flow.stages].sort((a, b) => a.order - b.order);
+
+    for (const stage of orderedStages) {
+      const stageRun = run.stageRuns.find((sr) => sr.stageId === stage.id);
+      if (!stageRun) continue;
+
+      // Skip stages already completed (resume from approval gate).
+      if (stageRun.status === "completed" || stageRun.status === "skipped") continue;
+
+      // If this stage is awaiting approval, stop — caller resumes via
+      // /api/flows/runs/:runId/approve which calls executeFlowRun again.
+      if (stageRun.status === "awaiting_approval") {
+        run = (await FlowStore.updateRun(runId, {
+          status: "awaiting_approval",
+          currentStageId: stage.id,
+        })) || run;
+        return;
+      }
+
+      // Approval gate on a not-yet-run stage: pause without running.
+      if (stage.requiresApproval && stageRun.status === "pending") {
+        await markStage(runId, stage.id, {
+          status: "awaiting_approval",
+          startedAt: new Date().toISOString(),
+        });
+        run = (await FlowStore.updateRun(runId, {
+          status: "awaiting_approval",
+          currentStageId: stage.id,
+        })) || run;
+        return;
+      }
+
+      // Actually run the stage.
+      await markStage(runId, stage.id, {
+        status: "running",
+        startedAt: new Date().toISOString(),
+      });
+      run = (await FlowStore.updateRun(runId, {
+        status: "running",
+        currentStageId: stage.id,
+      })) || run;
+
+      try {
+        const priorOutputs: Record<string, unknown> = {};
+        for (const prev of orderedStages) {
+          if (prev.id === stage.id) break;
+          const prevRun = run.stageRuns.find((sr) => sr.stageId === prev.id);
+          if (prevRun?.output != null) priorOutputs[prev.name] = prevRun.output;
+        }
+        const prompt = buildStagePrompt({
+          flow,
+          stage,
+          priorOutputs,
+          initialContext: run.context || {},
+        });
+        const systemPrompt =
+          SYSTEM_PROMPTS[stage.assignedAgent as FlowAgentKey] || SYSTEM_PROMPTS.manager;
+        const lane = laneForAgent(stage.assignedAgent);
+        const reply = await executeProviderChat(
+          [{ role: "user", content: prompt }],
+          { systemPrompt, lane: lane as any },
+        );
+        await markStage(runId, stage.id, {
+          status: "completed",
+          completedAt: new Date().toISOString(),
+          output: reply,
+        });
+        // Refresh local snapshot
+        run = (await FlowStore.getRun(runId)) || run;
+        await logRuntimeEvent({
+          level: "info",
+          source: "server",
+          event: "flow.stage.completed",
+          detail: `${flow.slug} :: ${stage.name}`,
+          context: { runId, stageId: stage.id, agent: stage.assignedAgent },
+        });
+      } catch (err: any) {
+        const detail = err?.message || String(err);
+        await markStage(runId, stage.id, {
+          status: "failed",
+          completedAt: new Date().toISOString(),
+          error: detail,
+        });
+        await FlowStore.updateRun(runId, { status: "failed" });
+        await logRuntimeEvent({
+          level: "error",
+          source: "server",
+          event: "flow.stage.failed",
+          detail,
+          context: {
+            runId,
+            stageId: stage.id,
+            agent: stage.assignedAgent,
+            errorKind: err?.constructor?.name,
+          },
+        });
+        return;
+      }
+    }
+
+    await FlowStore.updateRun(runId, {
+      status: "completed",
+      completedAt: new Date().toISOString(),
+      currentStageId: undefined,
+    });
+    await logRuntimeEvent({
+      level: "info",
+      source: "server",
+      event: "flow.run.completed",
+      detail: `${flow.slug} :: run ${runId.slice(0, 8)}`,
+      context: { runId, flow: flow.slug },
+    });
+  } finally {
+    inFlight.delete(runId);
+  }
+}
+
+async function markStage(
+  runId: string,
+  stageId: string,
+  patch: Partial<FlowStageRun>,
+): Promise<void> {
+  const run = await FlowStore.getRun(runId);
+  if (!run) return;
+  const stageRuns = run.stageRuns.map((sr) =>
+    sr.stageId === stageId ? { ...sr, ...patch } : sr,
+  );
+  await FlowStore.updateRun(runId, { stageRuns });
+}
+
+/**
+ * Approve the current awaiting_approval stage and continue. Returns the
+ * updated FlowRun (post-resume).
+ */
+export async function approveCurrentStage(runId: string, note?: string): Promise<FlowRun | null> {
+  const run = await FlowStore.getRun(runId);
+  if (!run || run.status !== "awaiting_approval" || !run.currentStageId) return run;
+  await markStage(runId, run.currentStageId, {
+    status: "completed",
+    completedAt: new Date().toISOString(),
+    notes: note ? `Approved: ${note}` : "Approved",
+  });
+  await FlowStore.updateRun(runId, { status: "running" });
+  // Resume async; caller doesn't have to wait
+  void executeFlowRun(runId);
+  return FlowStore.getRun(runId);
+}
+
+/**
+ * Reject the current awaiting_approval stage and cancel the run.
+ */
+export async function rejectCurrentStage(runId: string, reason?: string): Promise<FlowRun | null> {
+  const run = await FlowStore.getRun(runId);
+  if (!run || run.status !== "awaiting_approval" || !run.currentStageId) return run;
+  await markStage(runId, run.currentStageId, {
+    status: "failed",
+    completedAt: new Date().toISOString(),
+    error: reason ? `Rejected: ${reason}` : "Rejected by user",
+  });
+  await FlowStore.updateRun(runId, {
+    status: "cancelled",
+    completedAt: new Date().toISOString(),
+  });
+  return FlowStore.getRun(runId);
+}


### PR DESCRIPTION
## Flow execution engine — Launch button now actually runs flows

### New: `server/services/flow/FlowExecutor.ts`

- `executeFlowRun(runId)` iterates stages in order; per stage:
  - Marks running, builds prompt from `(flow purpose + stage goal + steps + initial run.context + prior stage outputs)`, dispatches via `executeProviderChat` using the lane that matches `stage.assignedAgent`
  - Stores reply on `stageRun.output`, advances to next stage
  - If `requiresApproval` → halts at `awaiting_approval`; resume via Approve API
  - Throws → marks stage `failed`, run `failed`, writes `flow.stage.failed` runtime log
- Re-entrant: per-runId in-flight guard prevents double-kickoff
- `approveCurrentStage` / `rejectCurrentStage` for approval gate transitions

### New endpoints

- `POST /api/flows/runs/:runId/approve`
- `POST /api/flows/runs/:runId/reject`
- `POST /api/flows/runs/:runId/resume` — manual nudge if a run got stuck

`POST /api/flows/:id/run` now fires `executeFlowRun(run.id)` async after creating the run.

### Runs UI (`client/src/pages/runs.tsx`)

- 3-second poll while status is `queued | running | awaiting_approval`
- Approve / Reject CTAs surface when at an approval gate
- Stage outputs render as collapsible markdown blocks once completed
- Stage names prettified (`s1-opportunity-detection` → "Opportunity Detection")

### Polish: avatar tooltip clip

Sidebar's "Click to upload photo" tooltip was anchored to `left-1/2 -translate-x-1/2`, overflowing the sidebar on mobile and getting clipped to "to upload photo". Re-anchored to `left-0` so it grows rightward, and hidden on mobile entirely (touch UIs don't have hover anyway).

## Commit
- `3acb4ea` Flow execution engine + run controls + avatar tooltip clip fix

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_