### PR TITLE
Tighten ZED system prompt: concise length + real markdown, no &lt;br&gt;

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -71,6 +71,12 @@ const ZED_IDENTITY_PROMPT = [
   "Use any provided memory context as background knowledge when it is relevant.",
   "If the knowledge context already identifies the company, project, brand, or user goals, answer from that context instead of asking broad generic follow-up questions.",
   "When the answer is grounded in known foundation, rules, or project memory, prefer a direct, specific response.",
+  // Length + format guidelines (added because output was too verbose
+  // and emitted literal <br> tags inside markdown):
+  "Match your response length to the question. Greetings get one short sentence. Simple factual questions get one direct answer. Reserve long structured responses for genuinely complex or multi-part requests.",
+  "Do not restate the question, do not write preamble like 'Great question!' or 'Here is the answer:', and do not summarize what you're about to say before saying it.",
+  "Output in GitHub-flavored markdown. Use **bold** for emphasis, bulleted or numbered lists for enumerations, tables for structured comparisons, and fenced code blocks for code. Never emit literal <br> or <br/> tags — use blank lines or list items instead.",
+  "If a table would help, render it as a real markdown table with pipes and a separator row. Don't paste the markdown source as plain text.",
 ].join(" ");
 
 export function setDatabaseStatus(status: boolean) {


### PR DESCRIPTION
## Problem

Two complaints visible in chat output:
1. **Too verbose** — short questions get wall-of-text responses
2. **Literal `<br>` tags** rendered inside markdown tables (because the model emits them as content instead of using real newlines/list items)

## Fix

Four new directives appended to `ZED_IDENTITY_PROMPT`:

- Match response length to the question (greeting = one sentence; simple factual = one direct answer)
- No preamble, no restating the question, no "Great question!" filler
- GitHub-flavored markdown only — real lists, real tables, fenced code; **never** emit literal `<br>` / `<br/>` tags
- If a table would help, render a proper pipe table with separator row instead of pasting markdown source as text

Combined with the react-markdown renderer (PR #44), assistant output should now both render correctly AND be appropriately sized.

## Commit
- `02a920f` Tighten ZED system prompt

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_