### PR TITLE
Integrations: multi-account + Google + button-driven UI

### DIFF
--- a/client/src/components/admin/sections/IntegrationsSection.tsx
+++ b/client/src/components/admin/sections/IntegrationsSection.tsx
@@ -1,20 +1,38 @@
 import { useEffect, useState } from "react";
-import { Bot, RefreshCw, Save } from "lucide-react";
+import {
+  Bot,
+  CheckCircle2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+  X,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea";
-import { LabeledField, ToggleField, humanizeFieldName } from "@/components/admin/fields";
-import { integrationMeta, StatusDot, type IntegrationKey } from "@/components/admin/types";
+import { Input } from "@/components/ui/input";
+import {
+  integrationMeta,
+  StatusDot,
+  type IntegrationKey,
+} from "@/components/admin/types";
 
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
+interface IntegrationsSettings {
+  [key: string]: any;
+}
+
+/** Which integrations now use the multi-account pattern. */
+const ACCOUNT_INTEGRATIONS = new Set<IntegrationKey>(["github", "email", "google"]);
+
 export default function IntegrationsSection() {
-  const [adminSettings, setAdminSettings] = useState<any>(null);
-  const [draft, setDraft] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
+  const [draft, setDraft] = useState<IntegrationsSettings | null>(null);
   const [active, setActive] = useState<IntegrationKey>("aiHost");
+  const [loading, setLoading] = useState(false);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [aiHostStatus, setAiHostStatus] = useState<any>(null);
   const [aiHostTest, setAiHostTest] = useState<{
@@ -22,6 +40,7 @@ export default function IntegrationsSection() {
     detail?: string;
     payload?: any;
   }>({ status: "idle" });
+  const [editingAccount, setEditingAccount] = useState<string | null>(null);
 
   async function fetchSettings() {
     setLoading(true);
@@ -29,7 +48,6 @@ export default function IntegrationsSection() {
       const res = await fetch("/api/admin/settings", { credentials: "include" });
       if (res.ok) {
         const data = await res.json();
-        setAdminSettings(data);
         setDraft(data.integrations);
       }
     } catch {}
@@ -48,14 +66,6 @@ export default function IntegrationsSection() {
     void fetchAiHostStatus();
   }, []);
 
-  function updateField(key: string, value: any) {
-    setDraft((prev: any) => ({
-      ...prev,
-      [active]: { ...prev?.[active], [key]: value },
-    }));
-    setSaveStatus("idle");
-  }
-
   async function save() {
     if (!draft) return;
     setSaveStatus("saving");
@@ -71,10 +81,59 @@ export default function IntegrationsSection() {
       setDraft((prev: any) => ({ ...prev, [active]: updated[active] }));
       setSaveStatus("saved");
       setTimeout(() => setSaveStatus("idle"), 2000);
-      await fetchSettings();
     } catch {
       setSaveStatus("error");
     }
+  }
+
+  function updateActiveField(key: string, value: any) {
+    setDraft((prev: any) => ({
+      ...prev,
+      [active]: { ...prev?.[active], [key]: value },
+    }));
+    setSaveStatus("idle");
+  }
+
+  function updateAccount(accountId: string, patch: any) {
+    setDraft((prev: any) => ({
+      ...prev,
+      [active]: {
+        ...prev?.[active],
+        accounts: (prev?.[active]?.accounts || []).map((a: any) =>
+          a.id === accountId ? { ...a, ...patch } : a,
+        ),
+      },
+    }));
+    setSaveStatus("idle");
+  }
+
+  function addAccount() {
+    const id = `${active}-${Date.now()}`;
+    const template = ACCOUNT_TEMPLATES[active as keyof typeof ACCOUNT_TEMPLATES];
+    if (!template) return;
+    const newAccount = { ...template, id };
+    setDraft((prev: any) => ({
+      ...prev,
+      [active]: {
+        ...prev?.[active],
+        accounts: [...(prev?.[active]?.accounts || []), newAccount],
+      },
+    }));
+    setEditingAccount(id);
+    setSaveStatus("idle");
+  }
+
+  function removeAccount(accountId: string) {
+    if (!window.confirm("Remove this account?")) return;
+    setDraft((prev: any) => ({
+      ...prev,
+      [active]: {
+        ...prev?.[active],
+        accounts: (prev?.[active]?.accounts || []).filter((a: any) => a.id !== accountId),
+      },
+    }));
+    setEditingAccount(null);
+    setSaveStatus("idle");
   }
 
   async function testAiHost() {
@@ -91,32 +150,25 @@ export default function IntegrationsSection() {
       if (!res.ok) {
         setAiHostTest({
           status: "error",
-          detail:
-            data?.error ||
-            `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}`,
-          payload: data ?? { http: res.status },
+          detail: data?.error || `HTTP ${res.status}`,
+          payload: data,
         });
         return;
       }
       if (data?.chat?.status === "ok") {
+        setAiHostTest({ status: "ok", detail: data.chat.reply, payload: data });
+      } else {
         setAiHostTest({
-          status: "ok",
-          detail: data.chat.reply || "AI host answered successfully.",
+          status: "error",
+          detail: data?.chat?.error || "Provider returned an error.",
           payload: data,
         });
-      } else {
-        const msg =
-          data?.chat?.error ||
-          data?.error ||
-          "Provider returned an error with no message.";
-        setAiHostTest({ status: "error", detail: msg, payload: data });
       }
       await fetchAiHostStatus();
-    } catch (error: any) {
+    } catch (e: any) {
       setAiHostTest({
         status: "error",
-        detail: error?.message || String(error) || "Network error",
-        payload: { caught: error?.message || String(error) },
+        detail: e?.message || "Network error",
       });
     }
   }
@@ -125,31 +177,29 @@ export default function IntegrationsSection() {
 
   return (
     <>
-      <div className="space-y-1">
+      <div>
         <h2 className="text-lg font-semibold">Integrations</h2>
-        <p className="text-sm text-muted-foreground">
-          Pick a feature or agent lane first, then work inside that specific section only.
-        </p>
       </div>
 
       <div className="flex flex-wrap gap-2">
         {(Object.keys(integrationMeta) as IntegrationKey[]).map((key) => {
           const meta = integrationMeta[key];
-          const Icon = meta.icon;
+          const Icon = meta.icon as LucideIcon;
+          const isActive = active === key;
           return (
             <button
               key={key}
-              onClick={() => setActive(key)}
-              className={`flex items-center gap-2 rounded-xl border px-3 py-2 text-sm transition-all ${
-                active === key
+              onClick={() => {
+                setActive(key);
+                setEditingAccount(null);
+              }}
+              className={`flex items-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs transition-all ${
+                isActive
                   ? "border-cyan-400/40 bg-white/10 text-white"
                   : "border-white/10 bg-black/20 text-muted-foreground hover:text-foreground"
               }`}
             >
-              <Icon
-                size={14}
-                className={active === key ? "text-cyan-300" : "text-muted-foreground"}
-              />
+              <Icon size={12} className={isActive ? "text-cyan-300" : ""} />
               <span>{meta.label}</span>
             </button>
           );
@@ -157,30 +207,627 @@ export default function IntegrationsSection() {
       </div>
 
       {loading ? (
-        <div className="text-center text-muted-foreground py-12">Loading…</div>
+        <div className="text-center text-muted-foreground py-8 text-sm">Loading…</div>
       ) : active === "aiHost" ? (
-        <AiHostPanel
-          status={aiHostStatus}
-          test={aiHostTest}
-          onTest={testAiHost}
+        <AiHostPanel status={aiHostStatus} test={aiHostTest} onTest={testAiHost} />
+      ) : ACCOUNT_INTEGRATIONS.has(active) ? (
+        <MultiAccountPanel
+          integrationKey={active}
+          draft={selectedDraft}
+          editingAccount={editingAccount}
+          onSetEditing={setEditingAccount}
+          onToggleEnabled={(v) => updateActiveField("enabled", v)}
+          onAdd={addAccount}
+          onRemove={removeAccount}
+          onAccountUpdate={updateAccount}
+          onSave={save}
+          saveStatus={saveStatus}
         />
       ) : !selectedDraft ? (
-        <Card className="zed-glass border-white/10">
-          <CardContent className="py-10 text-sm text-muted-foreground">
-            This integration section is not available yet.
-          </CardContent>
-        </Card>
+        <EmptyIntegrationCard />
       ) : (
-        <IntegrationFormCard
-          activeKey={active}
+        <SimpleIntegrationPanel
+          integrationKey={active}
           draft={selectedDraft}
-          onChange={updateField}
+          onUpdate={updateActiveField}
           onSave={save}
           saveStatus={saveStatus}
         />
       )}
     </>
   );
+}
+
+const ACCOUNT_TEMPLATES = {
+  github: {
+    label: "New repo",
+    owner: "",
+    repo: "",
+    defaultBranch: "main",
+    token: "",
+    hasToken: false,
+  },
+  email: {
+    label: "New sender",
+    provider: "smtp",
+    fromName: "ZED",
+    fromAddress: "",
+    smtpHost: "smtp.gmail.com",
+    smtpPort: 587,
+    username: "",
+    password: "",
+    hasPassword: false,
+  },
+  google: {
+    label: "New Google account",
+    email: "",
+    clientId: "",
+    clientSecret: "",
+    refreshToken: "",
+    hasCredentials: false,
+    scopes: ["https://www.googleapis.com/auth/gmail.send"],
+  },
+} as const;
+
+function EmptyIntegrationCard() {
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/25 p-6 text-center text-sm text-muted-foreground">
+      Not available yet.
+    </div>
+  );
+}
+
+function MultiAccountPanel({
+  integrationKey,
+  draft,
+  editingAccount,
+  onSetEditing,
+  onToggleEnabled,
+  onAdd,
+  onRemove,
+  onAccountUpdate,
+  onSave,
+  saveStatus,
+}: {
+  integrationKey: IntegrationKey;
+  draft: any;
+  editingAccount: string | null;
+  onSetEditing: (id: string | null) => void;
+  onToggleEnabled: (v: boolean) => void;
+  onAdd: () => void;
+  onRemove: (id: string) => void;
+  onAccountUpdate: (id: string, patch: any) => void;
+  onSave: () => void;
+  saveStatus: SaveStatus;
+}) {
+  const accounts = draft?.accounts || [];
+  const meta = integrationMeta[integrationKey];
+
+  return (
+    <div className="space-y-3">
+      {/* Top bar: enabled toggle + add */}
+      <div className="flex items-center justify-between gap-2 rounded-xl border border-white/10 bg-black/30 px-3 py-2.5">
+        <button
+          type="button"
+          onClick={() => onToggleEnabled(!draft?.enabled)}
+          className="flex items-center gap-2 text-sm"
+        >
+          <span
+            className={`flex h-5 w-9 items-center rounded-full p-0.5 transition-colors ${
+              draft?.enabled ? "justify-end bg-emerald-500/60" : "justify-start bg-white/15"
+            }`}
+          >
+            <span className="h-4 w-4 rounded-full bg-white shadow" />
+          </span>
+          <span>{draft?.enabled ? "Enabled" : "Disabled"}</span>
+        </button>
+        <Button
+          size="sm"
+          onClick={onAdd}
+          className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 h-8"
+        >
+          <Plus size={13} className="mr-1" />
+          Add {accountLabelSingular(integrationKey)}
+        </Button>
+      </div>
+
+      {/* Accounts list */}
+      {accounts.length === 0 ? (
+        <div className="rounded-xl border border-white/10 bg-black/20 p-6 text-center">
+          <p className="text-sm text-foreground">No {accountLabelPlural(integrationKey)} yet</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Tap <strong>Add {accountLabelSingular(integrationKey)}</strong> to wire one up.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {accounts.map((acc: any) => (
+            <AccountRow
+              key={acc.id}
+              integrationKey={integrationKey}
+              account={acc}
+              expanded={editingAccount === acc.id}
+              onToggle={() =>
+                onSetEditing(editingAccount === acc.id ? null : acc.id)
+              }
+              onUpdate={(patch) => onAccountUpdate(acc.id, patch)}
+              onRemove={() => onRemove(acc.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Save bar */}
+      <div className="flex items-center gap-2 pt-1">
+        <Button
+          onClick={onSave}
+          className="flex-1 bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+        >
+          {saveStatus === "saving"
+            ? "Saving…"
+            : saveStatus === "saved"
+              ? "Saved"
+              : saveStatus === "error"
+                ? "Save failed"
+                : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function accountLabelSingular(key: IntegrationKey) {
+  if (key === "github") return "repo";
+  if (key === "email") return "sender";
+  if (key === "google") return "Google account";
+  return "account";
+}
+function accountLabelPlural(key: IntegrationKey) {
+  if (key === "github") return "repos";
+  if (key === "email") return "senders";
+  if (key === "google") return "Google accounts";
+  return "accounts";
+}
+
+function AccountRow({
+  integrationKey,
+  account,
+  expanded,
+  onToggle,
+  onUpdate,
+  onRemove,
+}: {
+  integrationKey: IntegrationKey;
+  account: any;
+  expanded: boolean;
+  onToggle: () => void;
+  onUpdate: (patch: any) => void;
+  onRemove: () => void;
+}) {
+  const secretFilled =
+    integrationKey === "github"
+      ? !!account.hasToken
+      : integrationKey === "email"
+        ? !!account.hasPassword
+        : integrationKey === "google"
+          ? !!account.hasCredentials
+          : false;
+
+  const primary =
+    integrationKey === "github"
+      ? `${account.owner || "?"}/${account.repo || "?"}`
+      : integrationKey === "email"
+        ? account.fromAddress || account.username || "—"
+        : integrationKey === "google"
+          ? account.email || "—"
+          : "—";
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/30">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-3 py-2.5 text-left"
+      >
+        <span className="flex h-6 w-6 shrink-0 items-center justify-center">
+          {secretFilled ? (
+            <CheckCircle2 size={14} className="text-emerald-300" />
+          ) : (
+            <XCircle size={14} className="text-yellow-300" />
+          )}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium truncate">{account.label || "Untitled"}</div>
+          <div className="text-[11px] text-muted-foreground font-mono truncate">{primary}</div>
+        </div>
+        <Pencil size={13} className="text-muted-foreground" />
+      </button>
+
+      {expanded && (
+        <div className="space-y-2.5 border-t border-white/10 px-3 pt-2.5 pb-3">
+          {integrationKey === "github" && (
+            <GitHubAccountForm account={account} onUpdate={onUpdate} />
+          )}
+          {integrationKey === "email" && (
+            <EmailAccountForm account={account} onUpdate={onUpdate} />
+          )}
+          {integrationKey === "google" && (
+            <GoogleAccountForm account={account} onUpdate={onUpdate} />
+          )}
+          <div className="flex justify-between items-center pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onRemove}
+              className="text-red-300 hover:text-red-200 hover:bg-red-500/10 h-7 text-xs"
+            >
+              <Trash2 size={12} className="mr-1" />
+              Remove
+            </Button>
+            <Button type="button" variant="ghost" size="sm" onClick={onToggle} className="h-7 text-xs">
+              <X size={12} className="mr-1" />
+              Close
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FieldRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="space-y-1 block">
+      <span className="text-[10px] uppercase tracking-[0.18em] text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function GitHubAccountForm({
+  account,
+  onUpdate,
+}: {
+  account: any;
+  onUpdate: (patch: any) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2.5">
+      <FieldRow label="Label">
+        <Input
+          value={account.label || ""}
+          onChange={(e) => onUpdate({ label: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9"
+          placeholder="Personal repos"
+        />
+      </FieldRow>
+      <FieldRow label="Default branch">
+        <Input
+          value={account.defaultBranch || ""}
+          onChange={(e) => onUpdate({ defaultBranch: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9"
+          placeholder="main"
+        />
+      </FieldRow>
+      <FieldRow label="Owner">
+        <Input
+          value={account.owner || ""}
+          onChange={(e) => onUpdate({ owner: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder="xoclonholdings"
+        />
+      </FieldRow>
+      <FieldRow label="Repo">
+        <Input
+          value={account.repo || ""}
+          onChange={(e) => onUpdate({ repo: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder="ZedAI"
+        />
+      </FieldRow>
+      <div className="col-span-2">
+        <FieldRow label={account.hasToken ? "Token (saved)" : "Token"}>
+          <Input
+            type="password"
+            value={account.token || ""}
+            onChange={(e) => onUpdate({ token: e.target.value })}
+            className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+            placeholder={account.hasToken ? "•••••• — paste to replace" : "ghp_…"}
+          />
+        </FieldRow>
+      </div>
+    </div>
+  );
+}
+
+function EmailAccountForm({
+  account,
+  onUpdate,
+}: {
+  account: any;
+  onUpdate: (patch: any) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-2.5">
+      <FieldRow label="Label">
+        <Input
+          value={account.label || ""}
+          onChange={(e) => onUpdate({ label: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9"
+          placeholder="Personal Gmail"
+        />
+      </FieldRow>
+      <FieldRow label="Provider">
+        <select
+          value={account.provider || "smtp"}
+          onChange={(e) => onUpdate({ provider: e.target.value })}
+          className="w-full h-9 rounded-md border border-white/10 bg-black/30 px-2 text-sm"
+        >
+          <option value="smtp">SMTP</option>
+          <option value="gmail">Gmail</option>
+          <option value="outlook">Outlook</option>
+          <option value="icloud">iCloud</option>
+          <option value="custom">Custom</option>
+        </select>
+      </FieldRow>
+      <FieldRow label="From name">
+        <Input
+          value={account.fromName || ""}
+          onChange={(e) => onUpdate({ fromName: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9"
+          placeholder="ZED"
+        />
+      </FieldRow>
+      <FieldRow label="From address">
+        <Input
+          type="email"
+          value={account.fromAddress || ""}
+          onChange={(e) => onUpdate({ fromAddress: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9"
+          placeholder="zed@example.com"
+        />
+      </FieldRow>
+      <FieldRow label="SMTP host">
+        <Input
+          value={account.smtpHost || ""}
+          onChange={(e) => onUpdate({ smtpHost: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder="smtp.gmail.com"
+        />
+      </FieldRow>
+      <FieldRow label="Port">
+        <Input
+          type="number"
+          value={account.smtpPort || 587}
+          onChange={(e) => onUpdate({ smtpPort: Number(e.target.value) || 587 })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+        />
+      </FieldRow>
+      <FieldRow label="Username">
+        <Input
+          value={account.username || ""}
+          onChange={(e) => onUpdate({ username: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+        />
+      </FieldRow>
+      <FieldRow label={account.hasPassword ? "Password (saved)" : "Password"}>
+        <Input
+          type="password"
+          value={account.password || ""}
+          onChange={(e) => onUpdate({ password: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder={account.hasPassword ? "•••••• — paste to replace" : "app password"}
+        />
+      </FieldRow>
+    </div>
+  );
+}
+
+function GoogleAccountForm({
+  account,
+  onUpdate,
+}: {
+  account: any;
+  onUpdate: (patch: any) => void;
+}) {
+  const toggleScope = (scope: string) => {
+    const next = (account.scopes || []).includes(scope)
+      ? (account.scopes || []).filter((s: string) => s !== scope)
+      : [...(account.scopes || []), scope];
+    onUpdate({ scopes: next });
+  };
+  const COMMON_SCOPES: Array<{ key: string; label: string }> = [
+    { key: "https://www.googleapis.com/auth/gmail.send", label: "Gmail send" },
+    { key: "https://www.googleapis.com/auth/gmail.readonly", label: "Gmail read" },
+    { key: "https://www.googleapis.com/auth/calendar", label: "Calendar" },
+    { key: "https://www.googleapis.com/auth/drive.readonly", label: "Drive read" },
+  ];
+  return (
+    <div className="space-y-2.5">
+      <div className="grid grid-cols-2 gap-2.5">
+        <FieldRow label="Label">
+          <Input
+            value={account.label || ""}
+            onChange={(e) => onUpdate({ label: e.target.value })}
+            className="border-white/10 bg-black/30 text-sm h-9"
+            placeholder="Personal Gmail"
+          />
+        </FieldRow>
+        <FieldRow label="Google email">
+          <Input
+            type="email"
+            value={account.email || ""}
+            onChange={(e) => onUpdate({ email: e.target.value })}
+            className="border-white/10 bg-black/30 text-sm h-9"
+            placeholder="you@gmail.com"
+          />
+        </FieldRow>
+      </div>
+      <FieldRow label="Client ID">
+        <Input
+          value={account.clientId || ""}
+          onChange={(e) => onUpdate({ clientId: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder="123...apps.googleusercontent.com"
+        />
+      </FieldRow>
+      <FieldRow label={account.hasCredentials ? "Client secret (saved)" : "Client secret"}>
+        <Input
+          type="password"
+          value={account.clientSecret || ""}
+          onChange={(e) => onUpdate({ clientSecret: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder={account.hasCredentials ? "•••••• — paste to replace" : "GOCSPX-…"}
+        />
+      </FieldRow>
+      <FieldRow label={account.hasCredentials ? "Refresh token (saved)" : "Refresh token"}>
+        <Input
+          type="password"
+          value={account.refreshToken || ""}
+          onChange={(e) => onUpdate({ refreshToken: e.target.value })}
+          className="border-white/10 bg-black/30 text-sm h-9 font-mono"
+          placeholder={account.hasCredentials ? "•••••• — paste to replace" : "1//…"}
+        />
+      </FieldRow>
+      <FieldRow label="Scopes">
+        <div className="flex flex-wrap gap-1.5 pt-0.5">
+          {COMMON_SCOPES.map((s) => {
+            const on = (account.scopes || []).includes(s.key);
+            return (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => toggleScope(s.key)}
+                className={`rounded-md border px-2 py-1 text-[11px] transition-colors ${
+                  on
+                    ? "border-cyan-400/40 bg-cyan-500/15 text-cyan-100"
+                    : "border-white/10 bg-black/20 text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {s.label}
+              </button>
+            );
+          })}
+        </div>
+      </FieldRow>
+    </div>
+  );
+}
+
+function SimpleIntegrationPanel({
+  integrationKey,
+  draft,
+  onUpdate,
+  onSave,
+  saveStatus,
+}: {
+  integrationKey: IntegrationKey;
+  draft: any;
+  onUpdate: (key: string, value: any) => void;
+  onSave: () => void;
+  saveStatus: SaveStatus;
+}) {
+  const meta = integrationMeta[integrationKey];
+  const otherFields = Object.entries(draft).filter(
+    ([key]) => !["enabled", "status", "notes", "accounts"].includes(key),
+  );
+  return (
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3 space-y-2.5">
+      <div className="flex items-center justify-between gap-2 pb-1">
+        <button
+          type="button"
+          onClick={() => onUpdate("enabled", !draft.enabled)}
+          className="flex items-center gap-2 text-sm"
+        >
+          <span
+            className={`flex h-5 w-9 items-center rounded-full p-0.5 transition-colors ${
+              draft.enabled ? "justify-end bg-emerald-500/60" : "justify-start bg-white/15"
+            }`}
+          >
+            <span className="h-4 w-4 rounded-full bg-white shadow" />
+          </span>
+          <span>{draft.enabled ? "Enabled" : "Disabled"}</span>
+        </button>
+        {"status" in draft && (
+          <Badge
+            variant="secondary"
+            className="zed-glass border-white/10 text-[9px] uppercase tracking-[0.16em]"
+          >
+            {draft.status}
+          </Badge>
+        )}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2.5">
+        {otherFields.map(([key, value]) => {
+          if (typeof value === "boolean") {
+            return (
+              <FieldRow key={key} label={humanize(key)}>
+                <button
+                  type="button"
+                  onClick={() => onUpdate(key, !value)}
+                  className="flex h-9 items-center gap-2 rounded-md border border-white/10 bg-black/30 px-2 text-xs"
+                >
+                  <span
+                    className={`flex h-4 w-7 items-center rounded-full p-0.5 ${
+                      value ? "justify-end bg-emerald-500/60" : "justify-start bg-white/15"
+                    }`}
+                  >
+                    <span className="h-3 w-3 rounded-full bg-white" />
+                  </span>
+                  <span>{value ? "On" : "Off"}</span>
+                </button>
+              </FieldRow>
+            );
+          }
+          const isPort = key.toLowerCase().includes("port");
+          const isSecret =
+            key.toLowerCase().includes("token") ||
+            key.toLowerCase().includes("password") ||
+            key.toLowerCase().includes("apikey");
+          return (
+            <FieldRow key={key} label={humanize(key)}>
+              <Input
+                type={isSecret ? "password" : "text"}
+                value={String(value ?? "")}
+                onChange={(e) =>
+                  onUpdate(key, isPort ? Number(e.target.value) || 0 : e.target.value)
+                }
+                className="border-white/10 bg-black/30 text-sm h-9"
+                placeholder={isSecret ? "stored server-side or paste to replace" : ""}
+              />
+            </FieldRow>
+          );
+        })}
+      </div>
+
+      <Button
+        onClick={onSave}
+        className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+      >
+        {saveStatus === "saving"
+          ? "Saving…"
+          : saveStatus === "saved"
+            ? "Saved"
+            : saveStatus === "error"
+              ? "Save failed"
+              : "Save"}
+      </Button>
+    </div>
+  );
+}
+
+function humanize(s: string): string {
+  return s.replace(/([A-Z])/g, " $1").replace(/^./, (c) => c.toUpperCase());
 }
 
 function AiHostPanel({
@@ -199,184 +846,65 @@ function AiHostPanel({
   const isOnline = status?.ollama?.status === "online";
   const providerLabel = status?.ollama?.provider || "—";
   const models: string[] = status?.ollama?.models || [];
-
   return (
-    <Card className="zed-glass border-white/10">
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="flex items-center gap-2 text-base">
-            <Bot size={16} className="text-purple-300" />
-            AI Host
-          </CardTitle>
-          <Button
-            size="sm"
-            variant="outline"
-            className="zed-glass border-white/10 h-8"
-            onClick={onTest}
-            disabled={test.status === "testing"}
-            data-testid="aihost-test"
-          >
-            <RefreshCw
-              size={13}
-              className={`mr-1 ${test.status === "testing" ? "animate-spin" : ""}`}
-            />
-            {test.status === "testing" ? "Testing…" : "Test"}
-          </Button>
-        </div>
-      </CardHeader>
-
-      <CardContent className="space-y-3">
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3 space-y-3">
+      <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2 text-sm">
-          <StatusDot online={isOnline} />
-          <span className="capitalize">{status?.ollama?.status || "unknown"}</span>
-          <Badge
-            variant="secondary"
-            className="zed-glass border-white/10 text-[10px] uppercase tracking-[0.16em]"
-          >
-            {providerLabel}
-          </Badge>
-          {models.length > 0 && (
-            <span className="font-mono text-xs text-muted-foreground truncate">
-              {models[0]}
-              {models.length > 1 ? ` +${models.length - 1}` : ""}
-            </span>
-          )}
+          <Bot size={14} className="text-purple-300" />
+          AI Host
         </div>
-
-        {test.status === "ok" && (
-          <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs text-emerald-200">
-            <span className="font-medium">Provider replied:</span>{" "}
-            <span className="font-mono">{test.detail}</span>
-          </div>
-        )}
-
-        {test.status === "error" && (
-          <div className="rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-200 space-y-2">
-            <pre className="whitespace-pre-wrap break-all font-mono leading-5">
-              {test.detail || "Unknown error"}
-            </pre>
-            {test.payload && (
-              <details>
-                <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-red-300/80">
-                  raw response
-                </summary>
-                <pre className="mt-1 overflow-x-auto rounded bg-black/40 p-2 text-[10px] text-red-100/80">
-                  {JSON.stringify(test.payload, null, 2)}
-                </pre>
-              </details>
-            )}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function IntegrationFormCard({
-  activeKey,
-  draft,
-  onChange,
-  onSave,
-  saveStatus,
-}: {
-  activeKey: IntegrationKey;
-  draft: any;
-  onChange: (key: string, value: any) => void;
-  onSave: () => void;
-  saveStatus: SaveStatus;
-}) {
-  const meta = integrationMeta[activeKey];
-  const Icon = meta.icon;
-  const otherFields = Object.entries(draft).filter(
-    ([key]) => !["enabled", "status", "notes"].includes(key),
-  );
-
-  return (
-    <Card className="zed-glass border-white/10">
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-base">
-          <Icon size={16} className="text-cyan-300" />
-          {meta.label}
-        </CardTitle>
-        <CardDescription>{meta.description}</CardDescription>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <ToggleField
-          label="Enabled"
-          checked={!!draft.enabled}
-          onChange={(next) => onChange("enabled", next)}
-        />
-
-        {"status" in draft && (
-          <LabeledField
-            label="Status"
-            value={draft.status || ""}
-            onChange={(next) => onChange("status", next)}
+        <Button
+          size="sm"
+          variant="outline"
+          className="zed-glass border-white/10 h-8"
+          onClick={onTest}
+          disabled={test.status === "testing"}
+        >
+          <RefreshCw
+            size={13}
+            className={`mr-1 ${test.status === "testing" ? "animate-spin" : ""}`}
           />
+          {test.status === "testing" ? "Testing…" : "Test"}
+        </Button>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <StatusDot online={isOnline} />
+        <span className="capitalize">{status?.ollama?.status || "unknown"}</span>
+        <Badge
+          variant="secondary"
+          className="zed-glass border-white/10 text-[10px] uppercase tracking-[0.16em]"
+        >
+          {providerLabel}
+        </Badge>
+        {models.length > 0 && (
+          <span className="font-mono text-xs text-muted-foreground truncate">
+            {models[0]}
+            {models.length > 1 ? ` +${models.length - 1}` : ""}
+          </span>
         )}
-
-        <div className="grid gap-4 md:grid-cols-2">
-          {otherFields.map(([key, value]) => {
-            if (typeof value === "boolean") {
-              return (
-                <ToggleField
-                  key={key}
-                  label={humanizeFieldName(key)}
-                  checked={value}
-                  onChange={(next) => onChange(key, next)}
-                />
-              );
-            }
-            const isPort = key.toLowerCase().includes("port");
-            const isSecret =
-              key.toLowerCase().includes("token") ||
-              key.toLowerCase().includes("password") ||
-              key.toLowerCase().includes("apikey");
-            return (
-              <LabeledField
-                key={key}
-                label={humanizeFieldName(key)}
-                value={String(value ?? "")}
-                onChange={(next) => onChange(key, isPort ? Number(next) || 0 : next)}
-                placeholder={isSecret ? "Stored server-side or paste a new value" : undefined}
-              />
-            );
-          })}
+      </div>
+      {test.status === "ok" && (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2 text-xs text-emerald-200">
+          {test.detail}
         </div>
-
-        {"notes" in draft && (
-          <label className="space-y-2">
-            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              Notes
-            </span>
-            <Textarea
-              rows={5}
-              value={draft.notes || ""}
-              onChange={(e) => onChange("notes", e.target.value)}
-              className="zed-glass border-white/10 text-sm"
-            />
-          </label>
-        )}
-
-        <div className="flex items-center gap-3 pt-2">
-          <Button
-            onClick={onSave}
-            className="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
-          >
-            <Save size={14} className="mr-1" />
-            {saveStatus === "saving"
-              ? "Saving..."
-              : saveStatus === "saved"
-                ? "Saved!"
-                : saveStatus === "error"
-                  ? "Save failed"
-                  : "Save Changes"}
-          </Button>
-          {saveStatus === "error" && (
-            <span className="text-xs text-red-400">Could not save this section.</span>
+      )}
+      {test.status === "error" && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/5 px-3 py-2 text-xs text-red-200 space-y-1.5">
+          <pre className="whitespace-pre-wrap break-all font-mono leading-5">
+            {test.detail || "Unknown error"}
+          </pre>
+          {test.payload && (
+            <details>
+              <summary className="cursor-pointer text-[10px] uppercase tracking-[0.18em] text-red-300/80">
+                raw response
+              </summary>
+              <pre className="mt-1 overflow-x-auto rounded bg-black/40 p-2 text-[10px]">
+                {JSON.stringify(test.payload, null, 2)}
+              </pre>
+            </details>
           )}
         </div>
-      </CardContent>
-    </Card>
+      )}
+    </div>
   );
 }

--- a/client/src/components/admin/types.tsx
+++ b/client/src/components/admin/types.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   Bot,
   GitBranch,
+  Globe,
   Mail,
   Phone,
   Shield,
@@ -26,6 +27,7 @@ export type IntegrationKey =
   | "businessOperations"
   | "github"
   | "email"
+  | "google"
   | "telephony"
   | "firewall"
   | "gusto"
@@ -53,8 +55,13 @@ export const integrationMeta: Record<
   },
   email: {
     label: "Email",
-    description: "Executive assistant mail lane and sender identity.",
+    description: "Outbound senders. Multiple SMTP / IMAP accounts.",
     icon: Mail,
+  },
+  google: {
+    label: "Google",
+    description: "Gmail, Calendar, Drive. Multiple accounts.",
+    icon: Globe,
   },
   telephony: {
     label: "Telephony",

--- a/server/services/AdminSettingsStore.ts
+++ b/server/services/AdminSettingsStore.ts
@@ -156,25 +156,94 @@ function mergeSettings(raw: Partial<AdminSettings> | null | undefined): AdminSet
         ...defaultIntegrations.gusto,
         ...(raw?.integrations?.gusto || {}),
       },
-      github: {
-        ...defaultIntegrations.github,
-        ...(raw?.integrations?.github || {}),
-        hasToken: !!(raw?.integrations?.github?.token || raw?.integrations?.github?.hasToken),
-      },
+      github: (() => {
+        const merged = {
+          ...defaultIntegrations.github,
+          ...(raw?.integrations?.github || {}),
+          accounts: Array.isArray(raw?.integrations?.github?.accounts)
+            ? raw!.integrations!.github!.accounts!
+            : [],
+          hasToken: !!(raw?.integrations?.github?.token || raw?.integrations?.github?.hasToken),
+        };
+        // Migrate legacy single-repo fields → first account, if no
+        // accounts have been saved yet but legacy fields are populated.
+        if (
+          merged.accounts.length === 0 &&
+          (raw?.integrations?.github?.owner || raw?.integrations?.github?.repo)
+        ) {
+          merged.accounts = [
+            {
+              id: "github-account-primary",
+              label: `${raw?.integrations?.github?.owner || ""}/${raw?.integrations?.github?.repo || ""}`,
+              owner: raw?.integrations?.github?.owner || "",
+              repo: raw?.integrations?.github?.repo || "",
+              defaultBranch: raw?.integrations?.github?.defaultBranch || "main",
+              token: raw?.integrations?.github?.token || "",
+              hasToken: !!raw?.integrations?.github?.token,
+            },
+          ];
+        }
+        // Per-account hasToken flag.
+        merged.accounts = merged.accounts.map((acc: any) => ({
+          ...acc,
+          hasToken: !!(acc?.token || acc?.hasToken),
+        }));
+        return merged;
+      })(),
       email: (() => {
         const merged = {
           ...defaultIntegrations.email,
           ...(raw?.integrations?.email || {}),
-          hasPassword: !!(raw?.integrations?.email?.password || raw?.integrations?.email?.hasPassword),
+          accounts: Array.isArray(raw?.integrations?.email?.accounts)
+            ? raw!.integrations!.email!.accounts!
+            : [],
+          hasPassword: !!(
+            raw?.integrations?.email?.password || raw?.integrations?.email?.hasPassword
+          ),
         };
-        // Forward-migrate empty fields onto the iCloud / zed-ai.online defaults.
-        // Older files saved blanks for these; we want the canonical sender pre-filled
-        // so the only thing the admin still has to enter is auth username + app password.
-        if (!merged.fromAddress) merged.fromAddress = defaultIntegrations.email.fromAddress;
-        if (!merged.fromName) merged.fromName = defaultIntegrations.email.fromName;
-        if (!merged.smtpHost) merged.smtpHost = defaultIntegrations.email.smtpHost;
-        if (!merged.smtpPort) merged.smtpPort = defaultIntegrations.email.smtpPort;
+        // Migrate legacy single-sender fields → first account.
+        if (
+          merged.accounts.length === 0 &&
+          (raw?.integrations?.email?.fromAddress || raw?.integrations?.email?.username)
+        ) {
+          merged.accounts = [
+            {
+              id: "email-account-primary",
+              label: raw?.integrations?.email?.fromAddress || "Primary sender",
+              provider: raw?.integrations?.email?.provider || "smtp",
+              fromName: raw?.integrations?.email?.fromName || "ZED",
+              fromAddress: raw?.integrations?.email?.fromAddress || "",
+              smtpHost: raw?.integrations?.email?.smtpHost || "smtp.mail.me.com",
+              smtpPort: raw?.integrations?.email?.smtpPort || 587,
+              username: raw?.integrations?.email?.username || "",
+              password: raw?.integrations?.email?.password || "",
+              hasPassword: !!raw?.integrations?.email?.password,
+            },
+          ];
+        }
+        merged.accounts = merged.accounts.map((acc: any) => ({
+          ...acc,
+          hasPassword: !!(acc?.password || acc?.hasPassword),
+        }));
         if (!merged.notes) merged.notes = defaultIntegrations.email.notes;
+        return merged;
+      })(),
+      google: (() => {
+        const merged = {
+          ...defaultIntegrations.google,
+          ...(raw?.integrations?.google || {}),
+          accounts: Array.isArray(raw?.integrations?.google?.accounts)
+            ? raw!.integrations!.google!.accounts!
+            : [],
+        };
+        merged.accounts = merged.accounts.map((acc: any) => ({
+          ...acc,
+          scopes: Array.isArray(acc?.scopes) ? acc.scopes : [],
+          hasCredentials: !!(
+            (acc?.clientId && acc?.clientSecret && acc?.refreshToken) ||
+            acc?.hasCredentials
+          ),
+        }));
         return merged;
       })(),
       telephony: {
@@ -525,11 +594,30 @@ export async function getPublicAdminSettings() {
         ...settings.integrations.github,
         token: "",
         hasToken: !!settings.integrations.github.token,
+        accounts: (settings.integrations.github.accounts || []).map((acc) => ({
+          ...acc,
+          token: "",
+          hasToken: !!acc.token,
+        })),
       },
       email: {
         ...settings.integrations.email,
         password: "",
         hasPassword: !!settings.integrations.email.password,
+        accounts: (settings.integrations.email.accounts || []).map((acc) => ({
+          ...acc,
+          password: "",
+          hasPassword: !!acc.password,
+        })),
+      },
+      google: {
+        ...settings.integrations.google,
+        accounts: (settings.integrations.google.accounts || []).map((acc) => ({
+          ...acc,
+          clientSecret: "",
+          refreshToken: "",
+          hasCredentials: !!(acc.clientId && acc.clientSecret && acc.refreshToken),
+        })),
       },
       telephony: {
         ...settings.integrations.telephony,

--- a/shared/adminSettings.ts
+++ b/shared/adminSettings.ts
@@ -71,22 +71,36 @@ export interface GustoIntegrationSettings {
   notes: string;
 }
 
-export interface GitHubIntegrationSettings {
-  enabled: boolean;
-  status: "planned" | "configured" | "active";
-  apiBaseUrl: string;
+export interface GitHubAccount {
+  id: string;
+  label: string;
   owner: string;
   repo: string;
   defaultBranch: string;
   token: string;
   hasToken?: boolean;
+}
+
+export interface GitHubIntegrationSettings {
+  enabled: boolean;
+  status: "planned" | "configured" | "active";
+  apiBaseUrl: string;
+  /** Multi-account: list of repositories the integration tracks. */
+  accounts: GitHubAccount[];
+  /** Legacy fields preserved for backward-compat during migration.
+   *  Newly-saved data should use `accounts` instead. */
+  owner?: string;
+  repo?: string;
+  defaultBranch?: string;
+  token?: string;
+  hasToken?: boolean;
   notes: string;
 }
 
-export interface EmailIntegrationSettings {
-  enabled: boolean;
-  status: "planned" | "configured" | "active";
-  provider: "smtp" | "gmail" | "outlook" | "custom";
+export interface EmailAccount {
+  id: string;
+  label: string;
+  provider: "smtp" | "gmail" | "outlook" | "icloud" | "custom";
   fromName: string;
   fromAddress: string;
   smtpHost: string;
@@ -94,6 +108,43 @@ export interface EmailIntegrationSettings {
   username: string;
   password: string;
   hasPassword?: boolean;
+}
+
+export interface EmailIntegrationSettings {
+  enabled: boolean;
+  status: "planned" | "configured" | "active";
+  accounts: EmailAccount[];
+  /** Legacy fields preserved for backward-compat. */
+  provider?: "smtp" | "gmail" | "outlook" | "custom";
+  fromName?: string;
+  fromAddress?: string;
+  smtpHost?: string;
+  smtpPort?: number;
+  username?: string;
+  password?: string;
+  hasPassword?: boolean;
+  notes: string;
+}
+
+export interface GoogleAccount {
+  id: string;
+  label: string;
+  /** The Google account's primary email. */
+  email: string;
+  /** OAuth client (created in Google Cloud Console). */
+  clientId: string;
+  clientSecret: string;
+  /** Long-lived refresh token obtained via initial OAuth consent. */
+  refreshToken: string;
+  hasCredentials?: boolean;
+  /** Scopes enabled — e.g. "gmail.send", "gmail.readonly", "calendar". */
+  scopes: string[];
+}
+
+export interface GoogleIntegrationSettings {
+  enabled: boolean;
+  status: "planned" | "configured" | "active";
+  accounts: GoogleAccount[];
   notes: string;
 }
 
@@ -141,6 +192,7 @@ export interface IntegrationsSettings {
   gusto: GustoIntegrationSettings;
   github: GitHubIntegrationSettings;
   email: EmailIntegrationSettings;
+  google: GoogleIntegrationSettings;
   telephony: TelephonyIntegrationSettings;
   firewall: FirewallIntegrationSettings;
   businessOperations: BusinessOperationsSettings;
@@ -241,26 +293,23 @@ export const defaultIntegrations: IntegrationsSettings = {
     enabled: false,
     status: "planned",
     apiBaseUrl: "https://api.github.com",
-    owner: "",
-    repo: "",
-    defaultBranch: "main",
-    token: "",
-    hasToken: false,
-    notes: "GitHub integration for repository status, pull requests, issues, and future IDE/operator workflows.",
+    accounts: [],
+    notes:
+      "GitHub integration for repository status, pull requests, issues, and future IDE/operator workflows. Add one entry per repository you want ZED to access.",
   },
   email: {
     enabled: false,
     status: "planned",
-    provider: "smtp",
-    fromName: "ZED",
-    fromAddress: "zed@zed-ai.online",
-    smtpHost: "smtp.mail.me.com",
-    smtpPort: 587,
-    username: "",
-    password: "",
-    hasPassword: false,
+    accounts: [],
     notes:
-      "iCloud Custom Email Domain. Sender: zed@zed-ai.online (must be a verified custom-domain alias on the iCloud Apple ID). Auth username is the iCloud primary email; password must be an app-specific password generated at appleid.apple.com. DKIM/SPF records for zed-ai.online live in Netlify DNS. Set 'enabled' to true once the app password is saved.",
+      "Outbound email lanes. Add one account per sending identity (e.g. an iCloud custom-domain alias, a Gmail SMTP credential, etc.). Each account holds its own SMTP host, port, username, and app password.",
+  },
+  google: {
+    enabled: false,
+    status: "planned",
+    accounts: [],
+    notes:
+      "Google account integration for Gmail, Calendar, and Drive access. Add one account per Google identity. Each account needs an OAuth client (from Google Cloud Console) plus a refresh token obtained via the initial consent flow.",
   },
   telephony: {
     enabled: false,


### PR DESCRIPTION
## What changed

Integrations now support **multiple accounts per integration** + a new **Google** integration for Gmail/Calendar/Drive. The UI is button-driven instead of form-heavy.

### Schema

- New `GitHubAccount`, `EmailAccount`, `GoogleAccount` types with their own `id` + `label`
- `GitHubIntegrationSettings`, `EmailIntegrationSettings` carry `accounts: []`; legacy single-account fields preserved as optional for backward-compat
- New `GoogleIntegrationSettings` — each account holds `clientId / clientSecret / refreshToken` + a `scopes[]` whitelist

### Server migration

`mergeSettings()` forward-migrates legacy single-account configs into `accounts[0]` on load — existing GitHub/email setups don't get wiped. `getPublicAdminSettings()` strips secrets from every account, not just the top level.

### UI

- **MultiAccountPanel** for github/email/google: header bar (enabled toggle + Add button), account list as compact rows (label, primary identifier, status icon, edit chevron). Tap to expand inline form with Remove + Close.
- **SimpleIntegrationPanel** for the rest: pill toggles, no long descriptions, single Save button at bottom.
- Tabs across the top got tightened (1.5-line meta descriptions only).

## Caveat

Actual Google OAuth dance isn't in-app yet — admin pastes a refresh token fetched out-of-band (e.g. Google OAuth Playground). Fields + storage are ready for when full OAuth lands.

## Commit
- `2ac8f1a` Integrations: multi-account support + Google + button-driven UI

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_