### PR TITLE
Wave 1: avatar upload fix + custom integrations backend

### DIFF
--- a/client/src/components/chat/ChatSidebar.tsx
+++ b/client/src/components/chat/ChatSidebar.tsx
@@ -52,6 +52,38 @@ export default function ChatSidebar({
 }: ChatSidebarProps) {
   const [location, navigate] = useLocation();
   const queryClient = useQueryClient();
+  const [isUploadingPicture, setIsUploadingPicture] = useState(false);
+
+  async function handleAvatarUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setIsUploadingPicture(true);
+    try {
+      const formData = new FormData();
+      formData.append("photo", file);
+      const res = await fetch("/api/me/avatar", {
+        method: "POST",
+        credentials: "include",
+        body: formData,
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status}${body ? ` — ${body.slice(0, 160)}` : ""}`);
+      }
+      // Force /api/me to refetch so the new profileImageUrl flows
+      // through useAuth and the avatar updates immediately.
+      await queryClient.invalidateQueries({ queryKey: ["/api/me"] });
+      await queryClient.invalidateQueries({ queryKey: ["/api/auth/user"] });
+    } catch (err: any) {
+      console.error("[avatar] upload failed:", err);
+      window.alert(err?.message || "Avatar upload failed");
+    } finally {
+      setIsUploadingPicture(false);
+      // Reset the input so re-selecting the same file still triggers onChange
+      e.target.value = "";
+    }
+  }
+
   const [isCollapsed, setIsCollapsed] = useState(false);
   const { user, logout } = useAuth() as { user?: LocalUser; logout: () => Promise<void> };
   const [isLoggingOut, setIsLoggingOut] = useState(false);
@@ -234,8 +266,8 @@ export default function ChatSidebar({
 
       <ChatSidebarUserCard
         user={user}
-        isUploadingPicture={false}
-        onUpload={() => {}}
+        isUploadingPicture={isUploadingPicture}
+        onUpload={handleAvatarUpload}
         onLogout={handleLogout}
         isLoggingOut={isLoggingOut}
       />

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -271,6 +271,61 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Avatar upload — accepts a single image, stores under /uploads,
+  // sets the user's profileImageUrl, and refreshes the session.user
+  // so the next /api/me call returns the new URL.
+  app.post(
+    "/api/me/avatar",
+    isAuthenticated,
+    upload.single("photo"),
+    async (req: any, res) => {
+      try {
+        const file = req.file as Express.Multer.File | undefined;
+        if (!file) return res.status(400).json({ error: "No photo uploaded" });
+        if (!file.mimetype?.startsWith("image/")) {
+          return res.status(400).json({ error: "Photo must be an image" });
+        }
+        const userId = req.user?.claims?.sub;
+        if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+        // The file is on disk in uploads/. Build a URL that serves it
+        // back via the existing /uploads static route.
+        const publicUrl = `/uploads/${path.basename(file.path)}`;
+
+        // Persist on the users table if Drizzle is up.
+        try {
+          if (db) {
+            await db
+              .insert(users)
+              .values({ id: userId, profileImageUrl: publicUrl })
+              .onConflictDoUpdate({
+                target: users.id,
+                set: { profileImageUrl: publicUrl, updatedAt: new Date() },
+              });
+          }
+        } catch (dbErr: any) {
+          void logRuntimeEvent({
+            level: "warn",
+            source: "server",
+            event: "avatar.db_update_failed",
+            detail: dbErr?.message || String(dbErr),
+            context: { userId },
+          });
+        }
+
+        // Update the live session so the next /api/me reflects it
+        // without requiring a logout/login.
+        if (req.session?.user) {
+          req.session.user.profileImageUrl = publicUrl;
+        }
+
+        res.json({ profileImageUrl: publicUrl });
+      } catch (err: any) {
+        res.status(500).json({ error: err?.message || "Avatar upload failed" });
+      }
+    },
+  );
+
   app.get("/api/conversations", isAuthenticated, async (req: any, res) => {
     try {
       const userId = req.user.claims.sub;

--- a/server/services/AdminSettingsStore.ts
+++ b/server/services/AdminSettingsStore.ts
@@ -268,6 +268,21 @@ function mergeSettings(raw: Partial<AdminSettings> | null | undefined): AdminSet
         ...defaultIntegrations.voiceTranscription,
         ...(raw?.integrations?.voiceTranscription || {}),
       },
+      custom: Array.isArray((raw?.integrations as any)?.custom)
+        ? ((raw?.integrations as any).custom as any[]).map((c) => ({
+            id: c?.id || `custom-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            label: c?.label || "Custom integration",
+            description: c?.description || "",
+            enabled: !!c?.enabled,
+            fields: Array.isArray(c?.fields)
+              ? c.fields.map((f: any) => ({
+                  key: f?.key || "",
+                  value: f?.value || "",
+                  isSecret: !!f?.isSecret,
+                }))
+              : [],
+          }))
+        : [],
     },
     users: normalizeUsers(auth, raw?.users),
   };
@@ -619,6 +634,12 @@ export async function getPublicAdminSettings() {
           hasCredentials: !!(acc.clientId && acc.clientSecret && acc.refreshToken),
         })),
       },
+      custom: (settings.integrations.custom || []).map((c) => ({
+        ...c,
+        fields: (c.fields || []).map((f) =>
+          f.isSecret ? { ...f, value: f.value ? "•••••• (set)" : "" } : f,
+        ),
+      })),
       telephony: {
         ...settings.integrations.telephony,
         apiKey: "",

--- a/shared/adminSettings.ts
+++ b/shared/adminSettings.ts
@@ -209,6 +209,31 @@ export interface IntegrationsSettings {
     status: "planned" | "browser-only" | "active";
     provider: string;
   };
+  /** Admin-defined integrations. Each entry is an arbitrary integration
+   *  with named fields the user gives it. They surface in the ZED
+   *  context (so the model knows the tool exists) but ZED can only
+   *  ACT through them once a flow / agent is wired to consume the
+   *  fields. */
+  custom: CustomIntegration[];
+}
+
+export interface CustomIntegrationField {
+  /** Field name shown in the form (e.g. "API key", "Webhook URL"). */
+  key: string;
+  /** Value the admin enters. */
+  value: string;
+  /** If true, the value is masked in the public response and the
+   *  context builder doesn't reveal it. */
+  isSecret?: boolean;
+}
+
+export interface CustomIntegration {
+  id: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  /** Free-form fields the admin defined. */
+  fields: CustomIntegrationField[];
 }
 
 export interface AdminSettings {
@@ -361,4 +386,5 @@ export const defaultIntegrations: IntegrationsSettings = {
     status: "browser-only",
     provider: "Browser Speech API",
   },
+  custom: [],
 };


### PR DESCRIPTION
## Wave 1 of the 1-6 queue

### Avatar upload (#5) — fixed

Sidebar `onUpload` was `() => {}` and `isUploadingPicture` was hardcoded `false`. Tap did literally nothing.

- New `POST /api/me/avatar` accepts multipart `photo`, validates it's an image, persists to `users.profileImageUrl`, refreshes the session so `/api/me` shows it without a logout
- `ChatSidebar.handleAvatarUpload` POSTs the file, invalidates the auth queries, and resets the input so re-selecting the same file still fires `onChange`
- Loading spinner now wired to the upload state

### Custom integrations (#2 — backend only)

UI lands in Wave 2. This PR sets up the data shape so existing deploys boot cleanly.

- `CustomIntegration` + `CustomIntegrationField` types
- `integrations.custom: CustomIntegration[]` — admin-defined integrations with arbitrary `{ key, value, isSecret }` fields
- Server normalizes on load (auto-IDs, ensures `fields[]` is an array)
- `getPublicAdminSettings` masks secret values (replaces with `"•••••• (set)"`)

## Coming in Wave 2

- Custom integrations UI in IntegrationsSection
- Project sources endpoint + UI (#3)
- Project instructions endpoint + UI (#4)

## Coming in Wave 3

- Knowledge + Ruleset button-driven rewrite (#1)
- ZedContextBuilder verification + admin "What ZED sees" preview (#6)

## Commit
- `57795e9` Avatar upload + custom integrations backend

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_