### PR TITLE
Wave 2: project sources + instructions backend

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -46,9 +46,13 @@ import {
 } from "./services/AdminSettingsStore";
 import { getUserPersonalization, saveUserPersonalization } from "./services/UserPersonalizationStore";
 import {
+  addProjectSource,
   assignConversationToProject,
   createProject,
+  getProject,
   listProjects,
+  removeProjectSource,
+  updateProjectInstructions,
 } from "./services/ProjectFilingStore";
 import { HUB_CONFIG_DIR, HUB_LOG_DIR, HUB_SHARED_MEMORY_DIR } from "./utils/repoPaths";
 
@@ -597,6 +601,83 @@ export async function registerRoutes(app: Express): Promise<Server> {
       res.status(400).json({ error: error.message || "Failed to create project" });
     }
   });
+
+  app.get("/api/projects/:id", isAuthenticated, async (req: any, res) => {
+    try {
+      const project = await getProject(req.user.claims.sub, req.params.id);
+      if (!project) return res.status(404).json({ error: "Project not found" });
+      res.json(project);
+    } catch (error: any) {
+      res.status(500).json({ error: error.message || "Failed to load project" });
+    }
+  });
+
+  // Per-project system instructions — injected into the agent context
+  // for any conversation filed under this project.
+  app.put("/api/projects/:id/instructions", isAuthenticated, async (req: any, res) => {
+    try {
+      const project = await updateProjectInstructions(
+        req.user.claims.sub,
+        req.params.id,
+        String(req.body?.instructions || ""),
+      );
+      res.json({ project });
+    } catch (error: any) {
+      res.status(400).json({ error: error.message || "Failed to update instructions" });
+    }
+  });
+
+  // Add a source (file URL, pasted URL, or text snippet) to a project.
+  // Multipart upload sub-route accepts file=<File>, label, notes; the
+  // file lands at /uploads and the served URL becomes source.url.
+  app.post(
+    "/api/projects/:id/sources",
+    isAuthenticated,
+    upload.single("file"),
+    async (req: any, res) => {
+      try {
+        const userId = req.user.claims.sub;
+        const projectId = req.params.id;
+        const file = req.file as Express.Multer.File | undefined;
+        const label =
+          (req.body?.label && String(req.body.label).trim()) ||
+          (file?.originalname ? path.basename(file.originalname) : "Source");
+        const url = file
+          ? `/uploads/${path.basename(file.path)}`
+          : req.body?.url
+            ? String(req.body.url)
+            : undefined;
+        const text = req.body?.text ? String(req.body.text) : undefined;
+        const notes = req.body?.notes ? String(req.body.notes) : undefined;
+        const source = await addProjectSource(userId, projectId, {
+          label,
+          url,
+          text,
+          notes,
+        });
+        res.json({ source });
+      } catch (error: any) {
+        res.status(400).json({ error: error.message || "Failed to add source" });
+      }
+    },
+  );
+
+  app.delete(
+    "/api/projects/:id/sources/:sourceId",
+    isAuthenticated,
+    async (req: any, res) => {
+      try {
+        const project = await removeProjectSource(
+          req.user.claims.sub,
+          req.params.id,
+          req.params.sourceId,
+        );
+        res.json({ project });
+      } catch (error: any) {
+        res.status(400).json({ error: error.message || "Failed to remove source" });
+      }
+    },
+  );
 
   app.put("/api/conversations/:id/project", isAuthenticated, async (req: any, res) => {
     try {

--- a/server/services/ProjectFilingStore.ts
+++ b/server/services/ProjectFilingStore.ts
@@ -4,12 +4,31 @@ import { randomUUID } from "crypto";
 
 import { HUB_CONFIG_DIR } from "../utils/repoPaths";
 
+export interface ProjectSource {
+  id: string;
+  /** A short label the user gives the source ("Brand voice doc"). */
+  label: string;
+  /** Either an uploaded file URL (/uploads/...) OR a raw URL pasted by the user. */
+  url?: string;
+  /** Optional pasted text — for short snippets that don't need a file. */
+  text?: string;
+  /** Free-form note shown alongside the source in the UI. */
+  notes?: string;
+  /** ISO timestamp of when it was added. */
+  addedAt: string;
+}
+
 export interface FilingProject {
   id: string;
   userId: string;
   name: string;
   color: string;
   conversationIds: string[];
+  /** Per-project system prompt — gets injected into agent context when
+   *  a conversation is filed under this project. */
+  instructions?: string;
+  /** Files / URLs / snippets the project wants the agents to reference. */
+  sources?: ProjectSource[];
   createdAt: string;
   updatedAt: string;
 }
@@ -73,6 +92,73 @@ export async function createProject(userId: string, name: string) {
   };
 
   state.projects.push(project);
+  await writeState(state);
+  return project;
+}
+
+export async function getProject(userId: string, projectId: string) {
+  const state = await readState();
+  return state.projects.find(
+    (project) => project.userId === userId && project.id === projectId,
+  );
+}
+
+export async function updateProjectInstructions(
+  userId: string,
+  projectId: string,
+  instructions: string,
+) {
+  const state = await readState();
+  const project = state.projects.find(
+    (p) => p.userId === userId && p.id === projectId,
+  );
+  if (!project) throw new Error("Project not found");
+  project.instructions = (instructions || "").slice(0, 8000);
+  project.updatedAt = new Date().toISOString();
+  await writeState(state);
+  return project;
+}
+
+export async function addProjectSource(
+  userId: string,
+  projectId: string,
+  source: Omit<ProjectSource, "id" | "addedAt">,
+) {
+  const state = await readState();
+  const project = state.projects.find(
+    (p) => p.userId === userId && p.id === projectId,
+  );
+  if (!project) throw new Error("Project not found");
+  if (!source.label?.trim()) throw new Error("Source label is required");
+  if (!source.url && !source.text) {
+    throw new Error("Source must have either a url or text");
+  }
+  const entry: ProjectSource = {
+    id: randomUUID(),
+    label: source.label.trim().slice(0, 80),
+    url: source.url || undefined,
+    text: source.text ? source.text.slice(0, 16000) : undefined,
+    notes: source.notes ? source.notes.slice(0, 500) : undefined,
+    addedAt: new Date().toISOString(),
+  };
+  project.sources = [...(project.sources || []), entry];
+  project.updatedAt = entry.addedAt;
+  await writeState(state);
+  return entry;
+}
+
+export async function removeProjectSource(
+  userId: string,
+  projectId: string,
+  sourceId: string,
+) {
+  const state = await readState();
+  const project = state.projects.find(
+    (p) => p.userId === userId && p.id === projectId,
+  );
+  if (!project) throw new Error("Project not found");
+  project.sources = (project.sources || []).filter((s) => s.id !== sourceId);
+  project.updatedAt = new Date().toISOString();
   await writeState(state);
   return project;
 }


### PR DESCRIPTION
## Wave 2 — Project sources + instructions backend

Items #3 and #4 from the queue. Each project now carries:

- **`instructions`** — a per-project system-prompt string (8k char cap) that will flow into the agent context for any conversation filed under it
- **`sources[]`** — files / URLs / text snippets the agents will reference for this project

### Store additions

- `ProjectSource` type
- `getProject`, `updateProjectInstructions`, `addProjectSource`, `removeProjectSource`

### Routes

| Method | Path | What |
|---|---|---|
| GET | `/api/projects/:id` | Read project |
| PUT | `/api/projects/:id/instructions` | Set system prompt |
| POST | `/api/projects/:id/sources` | Add source (multipart `file=` upload OR `{ label, url, text, notes }`) |
| DELETE | `/api/projects/:id/sources/:sourceId` | Remove source |

Uploaded files go to `/uploads` via the existing multer config. The served URL becomes `source.url`.

### Not yet (next wave)

- UI to add / view / delete sources + edit instructions in the chat sidebar
- Injecting project instructions + sources into the ZED context builder so the agents actually USE them

## Commit
- `3b8d2c3` Project sources + instructions backend

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_