### PR TITLE
Modularize routes.ts wave 3: ai-host test + ruleset (-128 lines)

### DIFF
--- a/server/routes-modules/ai-host-test.ts
+++ b/server/routes-modules/ai-host-test.ts
@@ -1,0 +1,96 @@
+import type { Express } from "express";
+
+import { isAdmin } from "../localAuth";
+import {
+  checkOllamaHealth,
+  generateChatFromOllama,
+} from "../services/Ollama/OllamaService";
+import {
+  getActiveProviderName,
+  getResolvedTargetName,
+} from "../core/providers/provider-executor";
+import {
+  getActiveProviderDefaultModel,
+  getProviderRuntimeConfig,
+} from "../core/providers/provider-config";
+import { logRuntimeEvent } from "../services/RuntimeLogger";
+
+/**
+ * POST /api/admin/ai-host/test
+ *
+ * Round-trips one short prompt through the active provider and returns
+ * a structured pass/fail with the actual upstream error message — used
+ * by the admin Integrations → AI Host panel to diagnose provider
+ * misconfigurations (wrong URL, bad API key, billing, etc.) without
+ * tailing the server log.
+ */
+export function registerAiHostTestRoute(app: Express): void {
+  app.post("/api/admin/ai-host/test", isAdmin, async (_req, res) => {
+    try {
+      const health = await checkOllamaHealth();
+      const provider = getActiveProviderName({ lane: "chat" });
+      const target = getResolvedTargetName({ lane: "chat" });
+      const providerConfig = getProviderRuntimeConfig();
+      const model =
+        providerConfig.activeModel || getActiveProviderDefaultModel(providerConfig);
+
+      let chatStatus: "ok" | "error" = "ok";
+      let reply = "";
+      let error = "";
+      let errorKind = "";
+      const startedAt = Date.now();
+
+      try {
+        reply = await generateChatFromOllama(
+          [{ role: "user", content: "Reply with READY only." }],
+          undefined,
+          { lane: "manager" },
+        );
+      } catch (chatError: any) {
+        chatStatus = "error";
+        const message =
+          (typeof chatError?.message === "string" && chatError.message) ||
+          (typeof chatError === "string" && chatError) ||
+          "";
+        errorKind = chatError?.constructor?.name || "Error";
+        error =
+          message ||
+          (() => {
+            try {
+              return JSON.stringify(chatError);
+            } catch {
+              return String(chatError);
+            }
+          })();
+        await logRuntimeEvent({
+          level: "error",
+          source: "server",
+          event: "admin.ai_host.test_failed",
+          detail: error,
+          context: { provider, target, model, kind: errorKind },
+        });
+      }
+
+      res.json({
+        provider,
+        target,
+        model,
+        elapsedMs: Date.now() - startedAt,
+        health,
+        chat: { status: chatStatus, reply, error, errorKind },
+      });
+    } catch (error: any) {
+      res.status(500).json({
+        error:
+          error?.message ||
+          (() => {
+            try {
+              return JSON.stringify(error);
+            } catch {
+              return String(error);
+            }
+          })(),
+      });
+    }
+  });
+}

--- a/server/routes-modules/ruleset.ts
+++ b/server/routes-modules/ruleset.ts
@@ -1,0 +1,96 @@
+import fs from "fs/promises";
+import path from "path";
+import yaml from "js-yaml";
+import type { Express } from "express";
+
+import { isAdmin } from "../localAuth";
+import { HUB_CONFIG_DIR } from "../utils/repoPaths";
+import { ManagerAgent } from "../orchestrator/ManagerAgent";
+
+/**
+ * Ruleset YAML files that drive ZED's personality / security /
+ * parameters / access policy. Edited from Admin → Ruleset. After any
+ * write, ManagerAgent.flushConfig() clears the in-memory cache so the
+ * next call picks up the new rules.
+ */
+const RULESET_FILES = [
+  "personality.yaml",
+  "security.yaml",
+  "parameters.yaml",
+  "access.yaml",
+] as const;
+
+async function readYamlFile(filename: string): Promise<string> {
+  try {
+    return await fs.readFile(path.join(HUB_CONFIG_DIR, filename), "utf-8");
+  } catch {
+    return "";
+  }
+}
+
+async function writeRulesetFile(filename: string, content: string): Promise<void> {
+  await fs.mkdir(HUB_CONFIG_DIR, { recursive: true });
+  await fs.writeFile(path.join(HUB_CONFIG_DIR, filename), content, "utf-8");
+  ManagerAgent.flushConfig();
+}
+
+export function registerRulesetRoutes(app: Express): void {
+  // Raw YAML view — the legacy textarea editor reads this.
+  app.get("/api/admin/ruleset", isAdmin, async (_req, res) => {
+    const ruleset: Record<string, string> = {};
+    for (const f of RULESET_FILES) {
+      ruleset[f] = await readYamlFile(f);
+    }
+    res.json(ruleset);
+  });
+
+  // Parsed view — the structured form editor consumes this.
+  app.get("/api/admin/ruleset/structured", isAdmin, async (_req, res) => {
+    const ruleset: Record<string, any> = {};
+    for (const f of RULESET_FILES) {
+      const raw = await readYamlFile(f);
+      try {
+        ruleset[f] = raw ? yaml.load(raw) || {} : {};
+      } catch {
+        ruleset[f] = {};
+      }
+    }
+    res.json(ruleset);
+  });
+
+  // Raw YAML write — validates parseability before persisting.
+  app.post("/api/admin/ruleset", isAdmin, async (req: any, res) => {
+    const { filename, content } = req.body || {};
+    if (!RULESET_FILES.includes(filename)) {
+      return res.status(400).json({ error: "Invalid filename" });
+    }
+    try {
+      yaml.load(content);
+      await writeRulesetFile(filename, content);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  // Structured write — serializes the JSON-shaped content back to YAML,
+  // re-parses to validate, then persists.
+  app.post("/api/admin/ruleset/structured", isAdmin, async (req: any, res) => {
+    const { filename, content } = req.body || {};
+    if (!RULESET_FILES.includes(filename)) {
+      return res.status(400).json({ error: "Invalid filename" });
+    }
+    try {
+      const serialized = yaml.dump(content || {}, {
+        noRefs: true,
+        lineWidth: 120,
+        sortKeys: false,
+      });
+      yaml.load(serialized);
+      await writeRulesetFile(filename, serialized);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -43,6 +43,8 @@ import {
 import { getUserPersonalization, saveUserPersonalization } from "./services/UserPersonalizationStore";
 import { registerProjectRoutes } from "./routes-modules/projects";
 import { registerDiagnosticsRoutes } from "./routes-modules/diagnostics";
+import { registerAiHostTestRoute } from "./routes-modules/ai-host-test";
+import { registerRulesetRoutes } from "./routes-modules/ruleset";
 import { HUB_CONFIG_DIR, HUB_LOG_DIR, HUB_SHARED_MEMORY_DIR } from "./utils/repoPaths";
 
 import {
@@ -1019,80 +1021,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/admin/ai-host/test", isAdmin, async (_req, res) => {
-    try {
-      const health = await checkOllamaHealth();
-      const provider = getActiveProviderName({ lane: "chat" });
-      const target = getResolvedTargetName({ lane: "chat" });
-      const providerConfig = getProviderRuntimeConfig();
-      const model =
-        providerConfig.activeModel || getActiveProviderDefaultModel(providerConfig);
-
-      let chatStatus: "ok" | "error" = "ok";
-      let reply = "";
-      let error = "";
-      let errorKind = "";
-      const startedAt = Date.now();
-
-      try {
-        reply = await generateChatFromOllama(
-          [{ role: "user", content: "Reply with READY only." }],
-          undefined,
-          { lane: "manager" },
-        );
-      } catch (chatError: any) {
-        chatStatus = "error";
-        const message =
-          (typeof chatError?.message === "string" && chatError.message) ||
-          (typeof chatError === "string" && chatError) ||
-          "";
-        const constructor = chatError?.constructor?.name || "Error";
-        error =
-          message ||
-          (() => {
-            try {
-              return JSON.stringify(chatError);
-            } catch {
-              return String(chatError);
-            }
-          })();
-        errorKind = constructor;
-        await logRuntimeEvent({
-          level: "error",
-          source: "server",
-          event: "admin.ai_host.test_failed",
-          detail: error,
-          context: { provider, target, model, kind: errorKind },
-        });
-      }
-
-      res.json({
-        provider,
-        target,
-        model,
-        elapsedMs: Date.now() - startedAt,
-        health,
-        chat: {
-          status: chatStatus,
-          reply,
-          error,
-          errorKind,
-        },
-      });
-    } catch (error: any) {
-      res.status(500).json({
-        error:
-          error?.message ||
-          (() => {
-            try {
-              return JSON.stringify(error);
-            } catch {
-              return String(error);
-            }
-          })(),
-      });
-    }
-  });
+  // AI host connectivity test — extracted to routes-modules/ai-host-test.ts
+  registerAiHostTestRoute(app);
 
   app.get("/api/admin/settings", isAdmin, async (_req, res) => {
     const settings = await getPublicAdminSettings();
@@ -1174,18 +1104,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/admin/ruleset", isAdmin, async (_req, res) => {
-    const files = ["personality.yaml", "security.yaml", "parameters.yaml", "access.yaml"];
-    const ruleset: Record<string, string> = {};
-    for (const f of files) {
-      try {
-        ruleset[f] = await fs.readFile(path.join(HUB_CONFIG_DIR, f), "utf-8");
-      } catch {
-        ruleset[f] = "";
-      }
-    }
-    res.json(ruleset);
-  });
+  // Ruleset YAML CRUD (raw + structured) — extracted to routes-modules/ruleset.ts.
+  // ManagerAgent cache flush happens inside the module on every write.
+  registerRulesetRoutes(app);
 
   // ── Diagnostics (admin status snapshot + provider routing + runtime) ─
   // Extracted to routes-modules/diagnostics.ts. Database health is
@@ -1200,55 +1121,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Env validator — pure logic in services/EnvValidator.ts, thin route
   // wrapper in routes-modules/env-validate.ts.
   registerEnvValidateRoute(app);
-
-  app.get("/api/admin/ruleset/structured", isAdmin, async (_req, res) => {
-    const files = ["personality.yaml", "security.yaml", "parameters.yaml", "access.yaml"];
-    const ruleset: Record<string, any> = {};
-    for (const f of files) {
-      try {
-        const raw = await fs.readFile(path.join(HUB_CONFIG_DIR, f), "utf-8");
-        ruleset[f] = yaml.load(raw) || {};
-      } catch {
-        ruleset[f] = {};
-      }
-    }
-    res.json(ruleset);
-  });
-
-  app.post("/api/admin/ruleset", isAdmin, async (req: any, res) => {
-    const { filename, content } = req.body;
-    const allowed = ["personality.yaml", "security.yaml", "parameters.yaml", "access.yaml"];
-    if (!allowed.includes(filename)) {
-      return res.status(400).json({ error: "Invalid filename" });
-    }
-    try {
-      yaml.load(content);
-      await fs.mkdir(HUB_CONFIG_DIR, { recursive: true });
-      await fs.writeFile(path.join(HUB_CONFIG_DIR, filename), content, "utf-8");
-      ManagerAgent.flushConfig();
-      res.json({ success: true });
-    } catch (err: any) {
-      res.status(400).json({ error: err.message });
-    }
-  });
-
-  app.post("/api/admin/ruleset/structured", isAdmin, async (req: any, res) => {
-    const { filename, content } = req.body;
-    const allowed = ["personality.yaml", "security.yaml", "parameters.yaml", "access.yaml"];
-    if (!allowed.includes(filename)) {
-      return res.status(400).json({ error: "Invalid filename" });
-    }
-    try {
-      const serialized = yaml.dump(content || {}, { noRefs: true, lineWidth: 120, sortKeys: false });
-      yaml.load(serialized);
-      await fs.mkdir(HUB_CONFIG_DIR, { recursive: true });
-      await fs.writeFile(path.join(HUB_CONFIG_DIR, filename), serialized, "utf-8");
-      ManagerAgent.flushConfig();
-      res.json({ success: true });
-    } catch (err: any) {
-      res.status(400).json({ error: err.message });
-    }
-  });
 
   app.get("/api/admin/logs", isAdmin, async (_req, res) => {
     try {


### PR DESCRIPTION
routes.ts: 1,454 → 1,326. New modules:
- `routes-modules/ai-host-test.ts` (96 lines) — `POST /api/admin/ai-host/test`
- `routes-modules/ruleset.ts` (96 lines) — `/api/admin/ruleset` + `/api/admin/ruleset/structured`. ManagerAgent cache flush on every write.

Combined waves 1+2+3: 2,101 → 1,326 (-37%).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_