### PR TITLE
Split ChatArea send/mode logic into helpers (455 → 215 lines)

### DIFF
--- a/client/src/components/chat/ChatArea.tsx
+++ b/client/src/components/chat/ChatArea.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { notifyMessage } from "@/lib/notify";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuth } from "@/components/auth/UseAuth";
 
 import ChatBackground from "./ChatBackground";
@@ -8,6 +7,9 @@ import ChatComposer from "./ChatComposer";
 import ChatHeader from "./ChatHeader";
 import ChatMessagesList from "./ChatMessagesList";
 import FileUpload from "./FileUpload";
+import { sendAgentMessage } from "./chat-area/sendAgentMessage";
+import { sendChatMessage } from "./chat-area/sendChatMessage";
+import { useConversationMutations } from "./chat-area/useConversationMutations";
 
 import type {
   Conversation,
@@ -31,10 +33,7 @@ interface ChatAreaProps {
 export default function ChatArea({
   conversation,
   messages,
-  files,
   conversationId,
-  selectedProjectId,
-  onAssignProject,
   isMobile = false,
   onOpenSidebar,
 }: ChatAreaProps) {
@@ -54,11 +53,16 @@ export default function ChatArea({
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
   const abortRef = useRef<AbortController | null>(null);
+  const { updateModeMutation, ensureConversationTitle } = useConversationMutations(
+    conversation,
+    conversationId,
+  );
+
   const compactMessages = !!user?.personalization?.compactMessages;
-  const fontSize = (user?.personalization?.fontSize as "small" | "medium" | "large" | undefined) || "medium";
+  const fontSize =
+    (user?.personalization?.fontSize as "small" | "medium" | "large" | undefined) || "medium";
   const showTimestamps = !!user?.personalization?.showTimestamps;
 
-  // Keep localMessages in sync with prop (except when streaming)
   useEffect(() => {
     if (!isStreaming) {
       setLocalMessages(messages);
@@ -71,264 +75,7 @@ export default function ChatArea({
 
   useEffect(() => {
     scrollToBottom();
-  }, [localMessages, streamingMessage]);
-
-  const updateModeMutation = useMutation({
-    mutationFn: async (mode: ConversationMode) => {
-      if (!conversationId) return null;
-      const res = await fetch(`/api/conversations/${conversationId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ mode }),
-      });
-      if (!res.ok) throw new Error("Failed to update mode");
-      return res.json();
-    },
-    onSuccess: () => {
-      if (conversationId) {
-        queryClient.invalidateQueries({ queryKey: ["/api/conversations", conversationId] });
-      }
-    },
-  });
-
-  const renameConversationMutation = useMutation({
-    mutationFn: async ({ id, title }: { id: string; title: string }) => {
-      const res = await fetch(`/api/conversations/${id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ title }),
-      });
-      if (!res.ok) throw new Error("Failed to rename conversation");
-      return res.json();
-    },
-    onSuccess: (_data, vars) => {
-      queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
-      queryClient.invalidateQueries({ queryKey: ["/api/conversations", vars.id] });
-    },
-  });
-
-  async function ensureConversationTitle(convId: string, message: string) {
-    const rawTitle = (conversation?.title || "").trim().toLowerCase();
-    const shouldRename =
-      !conversation ||
-      !conversation.title ||
-      rawTitle === "new chat" ||
-      rawTitle === "new conversation" ||
-      rawTitle === "hello";
-
-    if (!shouldRename) return;
-
-    const title = message
-      .replace(/\s+/g, " ")
-      .trim()
-      .split(" ")
-      .slice(0, 8)
-      .join(" ");
-
-    if (title) {
-      await renameConversationMutation.mutateAsync({ id: convId, title });
-    }
-  }
-
-  // ─── SSE streaming chat (Chat mode) ──────────────────────────────────────
-
-  async function sendChatMessage(message: string, convId: string) {
-    abortRef.current?.abort();
-    abortRef.current = new AbortController();
-
-    setIsStreaming(true);
-    setStreamingMessage("");
-
-    // Optimistically add user message to local state
-    const tempUser: Message = {
-      id: `temp-user-${Date.now()}`,
-      conversationId: convId,
-      role: "user",
-      content: message,
-      metadata: null,
-      createdAt: new Date(),
-    };
-    setLocalMessages((prev) => [...prev, tempUser]);
-
-    try {
-      const res = await fetch(`/api/conversations/${convId}/messages`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ content: message, stream: true }),
-        signal: abortRef.current.signal,
-      });
-
-      if (!res.ok || !res.body) {
-        const detail = await res.text().catch(() => "");
-        throw new Error(
-          `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}${
-            detail ? ` — ${detail.slice(0, 200)}` : ""
-          }`,
-        );
-      }
-
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buf = "";
-      let aiContent = "";
-      let userMessageFromServer: Message | null = null;
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-
-        const lines = buf.split("\n");
-        buf = lines.pop() || "";
-
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          try {
-            const data = JSON.parse(line.slice(6));
-
-            if (data.type === "user_message") {
-              userMessageFromServer = data.message;
-            } else if (data.type === "token") {
-              aiContent += data.token;
-              setStreamingMessage(aiContent);
-            } else if (data.type === "done" || data.type === "error") {
-              const aiMessage: Message = data.message;
-              setStreamingMessage("");
-              setIsStreaming(false);
-              // Replace temp user message with real one, add AI message
-              setLocalMessages((prev) => {
-                const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
-                return [
-                  ...withoutTemp,
-                  userMessageFromServer || tempUser,
-                  aiMessage,
-                ];
-              });
-              // Browser notification when tab is in background
-              if (data.type === "done" && aiMessage?.content) {
-                notifyMessage("ZED", aiMessage.content);
-              }
-              // Refresh in background
-              queryClient.invalidateQueries({
-                queryKey: ["/api/conversations", convId, "messages"],
-              });
-              queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
-            }
-          } catch {}
-        }
-      }
-    } catch (err: any) {
-      if (err?.name === "AbortError") return;
-      console.error("[Chat] SSE error:", err);
-      setStreamingMessage("");
-      setIsStreaming(false);
-      const detail = err?.message || "unknown error";
-      const isAuthLike = /HTTP 40[1234]/.test(detail);
-      const friendly = isAuthLike
-        ? `${detail}. Try signing in again — your session may have expired.`
-        : `Chat request failed: ${detail}`;
-      setLocalMessages((prev) => [
-        ...prev,
-        {
-          id: `err-${Date.now()}`,
-          conversationId: convId,
-          role: "assistant",
-          content: friendly,
-          metadata: null,
-          createdAt: new Date(),
-        },
-      ]);
-    }
-  }
-
-  // ─── Agent mode orchestration ─────────────────────────────────────────────
-
-  async function sendAgentMessage(message: string, convId: string) {
-    setIsStreaming(true);
-
-    const tempUser: Message = {
-      id: `temp-user-${Date.now()}`,
-      conversationId: convId,
-      role: "user",
-      content: message,
-      metadata: null,
-      createdAt: new Date(),
-    };
-    setLocalMessages((prev) => [...prev, tempUser]);
-
-    try {
-      const res = await fetch("/api/orchestrate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ message, conversationId: convId, targetAgent: agentTarget }),
-      });
-
-      let data: any;
-      try {
-        data = await res.json();
-      } catch {
-        data = null;
-      }
-
-      let replyContent: string;
-      if (!res.ok) {
-        const isAuthLike = res.status === 401 || res.status === 403;
-        replyContent = isAuthLike
-          ? `Session expired (HTTP ${res.status}). Please sign in again.`
-          : data?.reply ||
-            data?.error ||
-            `Agent request failed: HTTP ${res.status} ${res.statusText || ""}`.trim();
-      } else {
-        replyContent = data?.reply || data?.error || "No response";
-      }
-
-      setLocalMessages((prev) => {
-        const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
-        return [
-          ...withoutTemp,
-          { ...tempUser, id: `user-${Date.now()}` },
-          {
-            id: `agent-${Date.now()}`,
-            conversationId: convId,
-            role: "assistant" as const,
-            content: replyContent,
-            metadata: { agent: data?.agent || "ManagerAgent" },
-            createdAt: new Date(),
-          },
-        ];
-      });
-
-      queryClient.invalidateQueries({
-        queryKey: ["/api/conversations", convId, "messages"],
-      });
-      queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
-    } catch (err: any) {
-      console.error("[Agent] Error:", err);
-      setLocalMessages((prev) => {
-        const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
-        return [
-          ...withoutTemp,
-          { ...tempUser, id: `user-${Date.now()}` },
-          {
-            id: `agent-err-${Date.now()}`,
-            conversationId: convId,
-            role: "assistant" as const,
-            content: `Agent request failed: ${err?.message || "network error"}`,
-            metadata: { agent: "ManagerAgent" },
-            createdAt: new Date(),
-          },
-        ];
-      });
-    } finally {
-      setIsStreaming(false);
-    }
-  }
-
-  // ─── Main send handler ────────────────────────────────────────────────────
+  }, [localMessages, streamingMessage, scrollToBottom]);
 
   async function handleSend(message: string) {
     if (!message.trim() || isStreaming) return;
@@ -345,9 +92,7 @@ export default function ChatArea({
           body: JSON.stringify({ title: message.slice(0, 50), mode: currentMode }),
         });
         const newConv = await res.json();
-        if (!newConv?.id) {
-          throw new Error("Conversation creation returned no id");
-        }
+        if (!newConv?.id) throw new Error("Conversation creation returned no id");
         convId = newConv.id;
         window.history.pushState({}, "", `/chat/${newConv.id}`);
         queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
@@ -362,13 +107,28 @@ export default function ChatArea({
     setComposerValue("");
 
     if (currentMode === "agent") {
-      await sendAgentMessage(message, convId!);
+      await sendAgentMessage({
+        message,
+        convId: convId!,
+        agentTarget,
+        setIsStreaming,
+        setLocalMessages,
+        queryClient,
+      });
     } else {
-      await sendChatMessage(message, convId!);
+      await sendChatMessage({
+        message,
+        convId: convId!,
+        abortRef,
+        setIsStreaming,
+        setStreamingMessage,
+        setLocalMessages,
+        queryClient,
+      });
     }
   }
 
-  async function handleModeToggle(mode: ConversationMode) {
+  function handleModeToggle(mode: ConversationMode) {
     setCurrentMode(mode);
     if (conversationId) {
       updateModeMutation.mutate(mode);

--- a/client/src/components/chat/chat-area/sendAgentMessage.ts
+++ b/client/src/components/chat/chat-area/sendAgentMessage.ts
@@ -1,0 +1,109 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, SetStateAction } from "react";
+
+import type { AgentTarget, Message } from "@shared/schema";
+
+interface SendAgentMessageArgs {
+  message: string;
+  convId: string;
+  agentTarget: AgentTarget;
+  setIsStreaming: Dispatch<SetStateAction<boolean>>;
+  setLocalMessages: Dispatch<SetStateAction<Message[]>>;
+  queryClient: QueryClient;
+}
+
+/**
+ * Agent-mode dispatch: posts to /api/orchestrate and appends the
+ * full reply when it comes back. No streaming — ManagerAgent returns
+ * a single response with the agent label in metadata. On failure,
+ * a synthetic assistant reply explains what went wrong (auth vs
+ * network vs other) so the conversation surface never dead-ends.
+ */
+export async function sendAgentMessage({
+  message,
+  convId,
+  agentTarget,
+  setIsStreaming,
+  setLocalMessages,
+  queryClient,
+}: SendAgentMessageArgs) {
+  setIsStreaming(true);
+
+  const tempUser: Message = {
+    id: `temp-user-${Date.now()}`,
+    conversationId: convId,
+    role: "user",
+    content: message,
+    metadata: null,
+    createdAt: new Date(),
+  };
+  setLocalMessages((prev) => [...prev, tempUser]);
+
+  try {
+    const res = await fetch("/api/orchestrate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ message, conversationId: convId, targetAgent: agentTarget }),
+    });
+
+    let data: any;
+    try {
+      data = await res.json();
+    } catch {
+      data = null;
+    }
+
+    let replyContent: string;
+    if (!res.ok) {
+      const isAuthLike = res.status === 401 || res.status === 403;
+      replyContent = isAuthLike
+        ? `Session expired (HTTP ${res.status}). Please sign in again.`
+        : data?.reply ||
+          data?.error ||
+          `Agent request failed: HTTP ${res.status} ${res.statusText || ""}`.trim();
+    } else {
+      replyContent = data?.reply || data?.error || "No response";
+    }
+
+    setLocalMessages((prev) => {
+      const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
+      return [
+        ...withoutTemp,
+        { ...tempUser, id: `user-${Date.now()}` },
+        {
+          id: `agent-${Date.now()}`,
+          conversationId: convId,
+          role: "assistant" as const,
+          content: replyContent,
+          metadata: { agent: data?.agent || "ManagerAgent" },
+          createdAt: new Date(),
+        },
+      ];
+    });
+
+    queryClient.invalidateQueries({
+      queryKey: ["/api/conversations", convId, "messages"],
+    });
+    queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
+  } catch (err: any) {
+    console.error("[Agent] Error:", err);
+    setLocalMessages((prev) => {
+      const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
+      return [
+        ...withoutTemp,
+        { ...tempUser, id: `user-${Date.now()}` },
+        {
+          id: `agent-err-${Date.now()}`,
+          conversationId: convId,
+          role: "assistant" as const,
+          content: `Agent request failed: ${err?.message || "network error"}`,
+          metadata: { agent: "ManagerAgent" },
+          createdAt: new Date(),
+        },
+      ];
+    });
+  } finally {
+    setIsStreaming(false);
+  }
+}

--- a/client/src/components/chat/chat-area/sendChatMessage.ts
+++ b/client/src/components/chat/chat-area/sendChatMessage.ts
@@ -1,0 +1,135 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+
+import { notifyMessage } from "@/lib/notify";
+import type { Message } from "@shared/schema";
+
+interface SendChatMessageArgs {
+  message: string;
+  convId: string;
+  abortRef: MutableRefObject<AbortController | null>;
+  setIsStreaming: Dispatch<SetStateAction<boolean>>;
+  setStreamingMessage: Dispatch<SetStateAction<string>>;
+  setLocalMessages: Dispatch<SetStateAction<Message[]>>;
+  queryClient: QueryClient;
+}
+
+/**
+ * Streams a chat-mode message over Server-Sent Events. Optimistically
+ * shows the user's turn, accumulates the assistant tokens into the
+ * streaming buffer, then commits both turns to local state on `done`.
+ *
+ * Errors surface as a synthetic assistant reply so the user always
+ * sees *something* rather than a silently dead composer.
+ */
+export async function sendChatMessage({
+  message,
+  convId,
+  abortRef,
+  setIsStreaming,
+  setStreamingMessage,
+  setLocalMessages,
+  queryClient,
+}: SendChatMessageArgs) {
+  abortRef.current?.abort();
+  abortRef.current = new AbortController();
+
+  setIsStreaming(true);
+  setStreamingMessage("");
+
+  const tempUser: Message = {
+    id: `temp-user-${Date.now()}`,
+    conversationId: convId,
+    role: "user",
+    content: message,
+    metadata: null,
+    createdAt: new Date(),
+  };
+  setLocalMessages((prev) => [...prev, tempUser]);
+
+  try {
+    const res = await fetch(`/api/conversations/${convId}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ content: message, stream: true }),
+      signal: abortRef.current.signal,
+    });
+
+    if (!res.ok || !res.body) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(
+        `HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}${
+          detail ? ` — ${detail.slice(0, 200)}` : ""
+        }`,
+      );
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    let aiContent = "";
+    let userMessageFromServer: Message | null = null;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+
+      const lines = buf.split("\n");
+      buf = lines.pop() || "";
+
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        try {
+          const data = JSON.parse(line.slice(6));
+
+          if (data.type === "user_message") {
+            userMessageFromServer = data.message;
+          } else if (data.type === "token") {
+            aiContent += data.token;
+            setStreamingMessage(aiContent);
+          } else if (data.type === "done" || data.type === "error") {
+            const aiMessage: Message = data.message;
+            setStreamingMessage("");
+            setIsStreaming(false);
+            setLocalMessages((prev) => {
+              const withoutTemp = prev.filter((m) => m.id !== tempUser.id);
+              return [...withoutTemp, userMessageFromServer || tempUser, aiMessage];
+            });
+            if (data.type === "done" && aiMessage?.content) {
+              notifyMessage("ZED", aiMessage.content);
+            }
+            queryClient.invalidateQueries({
+              queryKey: ["/api/conversations", convId, "messages"],
+            });
+            queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
+          }
+        } catch {
+          /* malformed SSE frame; skip and keep reading */
+        }
+      }
+    }
+  } catch (err: any) {
+    if (err?.name === "AbortError") return;
+    console.error("[Chat] SSE error:", err);
+    setStreamingMessage("");
+    setIsStreaming(false);
+    const detail = err?.message || "unknown error";
+    const isAuthLike = /HTTP 40[1234]/.test(detail);
+    const friendly = isAuthLike
+      ? `${detail}. Try signing in again — your session may have expired.`
+      : `Chat request failed: ${detail}`;
+    setLocalMessages((prev) => [
+      ...prev,
+      {
+        id: `err-${Date.now()}`,
+        conversationId: convId,
+        role: "assistant",
+        content: friendly,
+        metadata: null,
+        createdAt: new Date(),
+      },
+    ]);
+  }
+}

--- a/client/src/components/chat/chat-area/useConversationMutations.ts
+++ b/client/src/components/chat/chat-area/useConversationMutations.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import type { Conversation, ConversationMode } from "@shared/schema";
+
+/**
+ * Conversation-scoped mutations: switch chat/agent mode, rename, and
+ * the "first-message auto-title" rule used to upgrade a generic "New
+ * Chat" title into the first ~8 words the user typed.
+ */
+export function useConversationMutations(conversation?: Conversation, conversationId?: string) {
+  const queryClient = useQueryClient();
+
+  const updateModeMutation = useMutation({
+    mutationFn: async (mode: ConversationMode) => {
+      if (!conversationId) return null;
+      const res = await fetch(`/api/conversations/${conversationId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ mode }),
+      });
+      if (!res.ok) throw new Error("Failed to update mode");
+      return res.json();
+    },
+    onSuccess: () => {
+      if (conversationId) {
+        queryClient.invalidateQueries({ queryKey: ["/api/conversations", conversationId] });
+      }
+    },
+  });
+
+  const renameConversationMutation = useMutation({
+    mutationFn: async ({ id, title }: { id: string; title: string }) => {
+      const res = await fetch(`/api/conversations/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ title }),
+      });
+      if (!res.ok) throw new Error("Failed to rename conversation");
+      return res.json();
+    },
+    onSuccess: (_data, vars) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/conversations"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/conversations", vars.id] });
+    },
+  });
+
+  async function ensureConversationTitle(convId: string, message: string) {
+    const rawTitle = (conversation?.title || "").trim().toLowerCase();
+    const shouldRename =
+      !conversation ||
+      !conversation.title ||
+      rawTitle === "new chat" ||
+      rawTitle === "new conversation" ||
+      rawTitle === "hello";
+
+    if (!shouldRename) return;
+
+    const title = message
+      .replace(/\s+/g, " ")
+      .trim()
+      .split(" ")
+      .slice(0, 8)
+      .join(" ");
+
+    if (title) {
+      await renameConversationMutation.mutateAsync({ id: convId, title });
+    }
+  }
+
+  return { updateModeMutation, ensureConversationTitle };
+}


### PR DESCRIPTION
Splits the 455-line `ChatArea.tsx` so the shell is mostly state + JSX wiring and the heavy logic lives in focused helpers.

## Files

| File | Lines | Purpose |
| --- | --- | --- |
| `ChatArea.tsx` | 215 | Shell — state, props, `handleSend` dispatcher, JSX |
| `chat-area/sendChatMessage.ts` | 135 | SSE streaming chat send — temp user → token loop → committed turns + browser notification + cache invalidation + friendly error surface |
| `chat-area/sendAgentMessage.ts` | 109 | Agent-mode dispatch via `/api/orchestrate`, single-reply append, status-aware error messaging |
| `chat-area/useConversationMutations.ts` | 73 | `updateMode` + rename mutations + the first-message auto-title rule |

## Notes

- Each helper takes its required state setters as args. The shell stays the single owner of `localMessages` / streaming state — no hidden duplicate state.
- `files` / `selectedProjectId` / `onAssignProject` props were unused in the original component body (passed from `chat.tsx` but never consumed). Kept in the interface so the parent still type-checks; just not destructured.
- Tightened the empty `catch {}` in the SSE frame loop to explain it skips malformed frames and keeps reading.
- No behavior change — same send paths, same error messages, same query invalidation keys.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_