### PR TITLE
Split project-detail.tsx into source sub-components (410 → 210)

### DIFF
--- a/client/src/pages/project-detail.tsx
+++ b/client/src/pages/project-detail.tsx
@@ -1,40 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useParams } from "wouter";
-import {
-  ChevronLeft,
-  ExternalLink,
-  FileText,
-  Link as LinkIcon,
-  Loader2,
-  Plus,
-  Save,
-  Trash2,
-  Upload,
-} from "lucide-react";
+import { ChevronLeft, Plus, Save } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 
-interface ProjectSource {
-  id: string;
-  label: string;
-  url?: string;
-  text?: string;
-  notes?: string;
-  addedAt: string;
-}
-
-interface ProjectDetail {
-  id: string;
-  name: string;
-  color: string;
-  conversationIds: string[];
-  instructions?: string;
-  sources?: ProjectSource[];
-}
+import { AddSourceCard } from "./project-detail/AddSourceCard";
+import { SourceCard } from "./project-detail/SourceCard";
+import type { ProjectDetail } from "./project-detail/types";
 
 export default function ProjectDetailPage() {
   const [, navigate] = useLocation();
@@ -45,13 +19,6 @@ export default function ProjectDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [addOpen, setAddOpen] = useState(false);
-  const [addMode, setAddMode] = useState<"file" | "url" | "text">("file");
-  const [pendingLabel, setPendingLabel] = useState("");
-  const [pendingUrl, setPendingUrl] = useState("");
-  const [pendingText, setPendingText] = useState("");
-  const [pendingNotes, setPendingNotes] = useState("");
-  const [addingSource, setAddingSource] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function fetchProject() {
     if (!id) return;
@@ -96,57 +63,6 @@ export default function ProjectDetailPage() {
     }
   }
 
-  async function addSource() {
-    if (!id) return;
-    setAddingSource(true);
-    try {
-      let res: Response;
-      if (addMode === "file") {
-        const file = fileInputRef.current?.files?.[0];
-        if (!file) {
-          throw new Error("Pick a file first");
-        }
-        const fd = new FormData();
-        fd.append("file", file);
-        if (pendingLabel) fd.append("label", pendingLabel);
-        if (pendingNotes) fd.append("notes", pendingNotes);
-        res = await fetch(`/api/projects/${id}/sources`, {
-          method: "POST",
-          credentials: "include",
-          body: fd,
-        });
-      } else {
-        const payload: any = {
-          label: pendingLabel || (addMode === "url" ? pendingUrl : "Snippet"),
-          notes: pendingNotes || undefined,
-        };
-        if (addMode === "url") payload.url = pendingUrl;
-        if (addMode === "text") payload.text = pendingText;
-        res = await fetch(`/api/projects/${id}/sources`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          credentials: "include",
-          body: JSON.stringify(payload),
-        });
-      }
-      if (!res.ok) {
-        const body = await res.text().catch(() => "");
-        throw new Error(`HTTP ${res.status}${body ? ` — ${body.slice(0, 160)}` : ""}`);
-      }
-      setAddOpen(false);
-      setPendingLabel("");
-      setPendingUrl("");
-      setPendingText("");
-      setPendingNotes("");
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      await fetchProject();
-    } catch (e: any) {
-      setError(e?.message || "Failed to add source");
-    } finally {
-      setAddingSource(false);
-    }
-  }
-
   async function removeSource(sourceId: string) {
     if (!id || !window.confirm("Remove this source?")) return;
     try {
@@ -183,9 +99,7 @@ export default function ProjectDetailPage() {
               style={{ backgroundColor: project.color }}
             />
           )}
-          <span className="font-medium truncate max-w-[55vw]">
-            {project?.name || "Project"}
-          </span>
+          <span className="font-medium truncate max-w-[55vw]">{project?.name || "Project"}</span>
         </div>
         <span className="w-10" />
       </div>
@@ -205,7 +119,6 @@ export default function ProjectDetailPage() {
           </div>
         ) : (
           <>
-            {/* Instructions */}
             <section className="space-y-2">
               <div className="flex items-center justify-between">
                 <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -239,7 +152,6 @@ export default function ProjectDetailPage() {
               </p>
             </section>
 
-            {/* Sources */}
             <section className="space-y-2">
               <div className="flex items-center justify-between">
                 <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-muted-foreground">
@@ -256,76 +168,12 @@ export default function ProjectDetailPage() {
               </div>
 
               {addOpen && (
-                <Card className="zed-glass border-white/10">
-                  <CardContent className="p-3 space-y-2.5">
-                    <div className="flex gap-1.5">
-                      {(["file", "url", "text"] as const).map((m) => (
-                        <button
-                          key={m}
-                          type="button"
-                          onClick={() => setAddMode(m)}
-                          className={`flex-1 rounded-lg border px-2 py-1.5 text-xs transition-colors ${
-                            addMode === m
-                              ? "border-cyan-400/40 bg-cyan-500/15 text-cyan-100"
-                              : "border-white/10 bg-black/20 text-muted-foreground hover:text-foreground"
-                          }`}
-                        >
-                          {m === "file" ? "File" : m === "url" ? "URL" : "Text"}
-                        </button>
-                      ))}
-                    </div>
-                    <Input
-                      value={pendingLabel}
-                      onChange={(e) => setPendingLabel(e.target.value)}
-                      className="zed-glass border-white/10 h-9 text-sm"
-                      placeholder="Label (e.g. Brand voice doc)"
-                    />
-                    {addMode === "file" && (
-                      <Input
-                        ref={fileInputRef}
-                        type="file"
-                        className="zed-glass border-white/10 text-xs"
-                      />
-                    )}
-                    {addMode === "url" && (
-                      <Input
-                        value={pendingUrl}
-                        onChange={(e) => setPendingUrl(e.target.value)}
-                        className="zed-glass border-white/10 h-9 text-sm font-mono"
-                        placeholder="https://…"
-                      />
-                    )}
-                    {addMode === "text" && (
-                      <Textarea
-                        value={pendingText}
-                        onChange={(e) => setPendingText(e.target.value)}
-                        rows={5}
-                        className="zed-glass border-white/10 text-sm"
-                        placeholder="Paste a snippet the agents should know about…"
-                      />
-                    )}
-                    <Input
-                      value={pendingNotes}
-                      onChange={(e) => setPendingNotes(e.target.value)}
-                      className="zed-glass border-white/10 h-9 text-sm"
-                      placeholder="Notes (optional)"
-                    />
-                    <Button
-                      onClick={addSource}
-                      disabled={addingSource}
-                      className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
-                    >
-                      {addingSource ? (
-                        <Loader2 size={14} className="mr-2 animate-spin" />
-                      ) : addMode === "file" ? (
-                        <Upload size={14} className="mr-2" />
-                      ) : (
-                        <Plus size={14} className="mr-2" />
-                      )}
-                      Add source
-                    </Button>
-                  </CardContent>
-                </Card>
+                <AddSourceCard
+                  projectId={id!}
+                  onAdded={fetchProject}
+                  onError={setError}
+                  onCancel={() => setAddOpen(false)}
+                />
               )}
 
               {sources.length === 0 ? (
@@ -335,59 +183,11 @@ export default function ProjectDetailPage() {
               ) : (
                 <div className="space-y-1.5">
                   {sources.map((source) => (
-                    <Card key={source.id} className="zed-glass border-white/10">
-                      <CardContent className="p-3">
-                        <div className="flex items-start gap-2">
-                          <span className="mt-0.5 shrink-0">
-                            {source.url ? (
-                              <LinkIcon size={13} className="text-cyan-300" />
-                            ) : (
-                              <FileText size={13} className="text-purple-300" />
-                            )}
-                          </span>
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                              <span className="text-sm font-medium truncate">
-                                {source.label}
-                              </span>
-                              {source.url && (
-                                <a
-                                  href={source.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-cyan-300 hover:text-cyan-200"
-                                >
-                                  <ExternalLink size={11} />
-                                </a>
-                              )}
-                            </div>
-                            {source.url && (
-                              <p className="text-[11px] font-mono text-muted-foreground truncate">
-                                {source.url}
-                              </p>
-                            )}
-                            {source.text && (
-                              <p className="text-[11px] text-muted-foreground/90 line-clamp-2 leading-5 mt-0.5">
-                                {source.text}
-                              </p>
-                            )}
-                            {source.notes && (
-                              <p className="text-[11px] italic text-muted-foreground/80 mt-0.5">
-                                {source.notes}
-                              </p>
-                            )}
-                          </div>
-                          <button
-                            type="button"
-                            onClick={() => removeSource(source.id)}
-                            className="text-muted-foreground hover:text-red-300 shrink-0"
-                            aria-label="Remove source"
-                          >
-                            <Trash2 size={13} />
-                          </button>
-                        </div>
-                      </CardContent>
-                    </Card>
+                    <SourceCard
+                      key={source.id}
+                      source={source}
+                      onRemove={() => removeSource(source.id)}
+                    />
                   ))}
                 </div>
               )}

--- a/client/src/pages/project-detail/AddSourceCard.tsx
+++ b/client/src/pages/project-detail/AddSourceCard.tsx
@@ -1,0 +1,151 @@
+import { useRef, useState } from "react";
+import { Loader2, Plus, Upload } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+import type { AddSourceMode } from "./types";
+
+/**
+ * Three-mode source adder: file upload (multipart), URL reference,
+ * or pasted text snippet. Posts to /api/projects/:id/sources and
+ * tells the parent to refetch on success.
+ */
+export function AddSourceCard({
+  projectId,
+  onAdded,
+  onError,
+  onCancel,
+}: {
+  projectId: string;
+  onAdded: () => Promise<void>;
+  onError: (message: string) => void;
+  onCancel: () => void;
+}) {
+  const [mode, setMode] = useState<AddSourceMode>("file");
+  const [label, setLabel] = useState("");
+  const [url, setUrl] = useState("");
+  const [text, setText] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function submit() {
+    setSubmitting(true);
+    try {
+      let res: Response;
+      if (mode === "file") {
+        const file = fileInputRef.current?.files?.[0];
+        if (!file) throw new Error("Pick a file first");
+        const fd = new FormData();
+        fd.append("file", file);
+        if (label) fd.append("label", label);
+        if (notes) fd.append("notes", notes);
+        res = await fetch(`/api/projects/${projectId}/sources`, {
+          method: "POST",
+          credentials: "include",
+          body: fd,
+        });
+      } else {
+        const payload: any = {
+          label: label || (mode === "url" ? url : "Snippet"),
+          notes: notes || undefined,
+        };
+        if (mode === "url") payload.url = url;
+        if (mode === "text") payload.text = text;
+        res = await fetch(`/api/projects/${projectId}/sources`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(payload),
+        });
+      }
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status}${body ? ` — ${body.slice(0, 160)}` : ""}`);
+      }
+      setLabel("");
+      setUrl("");
+      setText("");
+      setNotes("");
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      await onAdded();
+      onCancel();
+    } catch (e: any) {
+      onError(e?.message || "Failed to add source");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Card className="zed-glass border-white/10">
+      <CardContent className="p-3 space-y-2.5">
+        <div className="flex gap-1.5">
+          {(["file", "url", "text"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMode(m)}
+              className={`flex-1 rounded-lg border px-2 py-1.5 text-xs transition-colors ${
+                mode === m
+                  ? "border-cyan-400/40 bg-cyan-500/15 text-cyan-100"
+                  : "border-white/10 bg-black/20 text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {m === "file" ? "File" : m === "url" ? "URL" : "Text"}
+            </button>
+          ))}
+        </div>
+        <Input
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="zed-glass border-white/10 h-9 text-sm"
+          placeholder="Label (e.g. Brand voice doc)"
+        />
+        {mode === "file" && (
+          <Input ref={fileInputRef} type="file" className="zed-glass border-white/10 text-xs" />
+        )}
+        {mode === "url" && (
+          <Input
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="zed-glass border-white/10 h-9 text-sm font-mono"
+            placeholder="https://…"
+          />
+        )}
+        {mode === "text" && (
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={5}
+            className="zed-glass border-white/10 text-sm"
+            placeholder="Paste a snippet the agents should know about…"
+          />
+        )}
+        <Input
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="zed-glass border-white/10 h-9 text-sm"
+          placeholder="Notes (optional)"
+        />
+        <Button
+          onClick={submit}
+          disabled={submitting}
+          className="w-full bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700"
+        >
+          {submitting ? (
+            <Loader2 size={14} className="mr-2 animate-spin" />
+          ) : mode === "file" ? (
+            <Upload size={14} className="mr-2" />
+          ) : (
+            <Plus size={14} className="mr-2" />
+          )}
+          Add source
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/project-detail/SourceCard.tsx
+++ b/client/src/pages/project-detail/SourceCard.tsx
@@ -1,0 +1,63 @@
+import { ExternalLink, FileText, Link as LinkIcon, Trash2 } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+import type { ProjectSource } from "./types";
+
+export function SourceCard({
+  source,
+  onRemove,
+}: {
+  source: ProjectSource;
+  onRemove: () => void;
+}) {
+  return (
+    <Card className="zed-glass border-white/10">
+      <CardContent className="p-3">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 shrink-0">
+            {source.url ? (
+              <LinkIcon size={13} className="text-cyan-300" />
+            ) : (
+              <FileText size={13} className="text-purple-300" />
+            )}
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium truncate">{source.label}</span>
+              {source.url && (
+                <a
+                  href={source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-cyan-300 hover:text-cyan-200"
+                >
+                  <ExternalLink size={11} />
+                </a>
+              )}
+            </div>
+            {source.url && (
+              <p className="text-[11px] font-mono text-muted-foreground truncate">{source.url}</p>
+            )}
+            {source.text && (
+              <p className="text-[11px] text-muted-foreground/90 line-clamp-2 leading-5 mt-0.5">
+                {source.text}
+              </p>
+            )}
+            {source.notes && (
+              <p className="text-[11px] italic text-muted-foreground/80 mt-0.5">{source.notes}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="text-muted-foreground hover:text-red-300 shrink-0"
+            aria-label="Remove source"
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/project-detail/types.ts
+++ b/client/src/pages/project-detail/types.ts
@@ -1,0 +1,19 @@
+export interface ProjectSource {
+  id: string;
+  label: string;
+  url?: string;
+  text?: string;
+  notes?: string;
+  addedAt: string;
+}
+
+export interface ProjectDetail {
+  id: string;
+  name: string;
+  color: string;
+  conversationIds: string[];
+  instructions?: string;
+  sources?: ProjectSource[];
+}
+
+export type AddSourceMode = "file" | "url" | "text";


### PR DESCRIPTION
Splits the 410-line `project-detail.tsx` into the page shell + two focused sub-components.

## Files

| File | Lines | Purpose |
| --- | --- | --- |
| `pages/project-detail.tsx` | 210 | Shell — fetch, instructions section, source list composition |
| `pages/project-detail/types.ts` | 19 | `ProjectDetail` + `ProjectSource` + `AddSourceMode` |
| `pages/project-detail/AddSourceCard.tsx` | 151 | File / URL / text mode-switching add form. Owns the multipart-vs-JSON branching internally. |
| `pages/project-detail/SourceCard.tsx` | 63 | Single source row — icon, label, optional URL/text/notes, remove button |

## Notes

- All form-specific state (label, url, text, notes, mode, file ref, submitting) moves into `AddSourceCard`. The shell only tracks `addOpen`.
- `AddSourceCard` receives `onAdded` (refetch) and `onError` (set parent error banner) so error surfacing stays in one place.
- No behavior change — same endpoints, same UX, same error path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_