### PR TITLE
Split ExternalCommandGateway into intake helpers (351 → 163 lines)

### DIFF
--- a/server/services/intake/ExternalCommandGateway.ts
+++ b/server/services/intake/ExternalCommandGateway.ts
@@ -1,10 +1,10 @@
 /**
  * ExternalCommandGateway
  *
- * Universal intake layer that normalizes external commands (app, voice,
- * SMS, WhatsApp, email, browser triggers, webhooks, future channels)
- * into Zed's unified task format and routes them through the existing
- * execution / approval / orchestration pipelines.
+ * Universal intake layer that normalizes external commands (app,
+ * voice, SMS, WhatsApp, email, browser triggers, webhooks, future
+ * channels) into Zed's unified task format and routes them through
+ * the existing execution / approval / orchestration pipelines.
  *
  * It does NOT execute anything itself. It only:
  *   1. Logs every incoming command.
@@ -12,105 +12,44 @@
  *   3. Builds an execution plan via TaskExecutionEngine.
  *   4. Persists a TaskRecord via TaskLifecycleManager.
  *   5. Lets ApprovalWatchdog set the correct approval state.
- *   6. Optionally runs a preview through ToolOrchestrationEngine
- *      (no execution; only recommended steps).
+ *   6. Runs a *preview* through ToolOrchestrationEngine (no
+ *      execution; only recommended steps).
+ *
+ * The helpers live under ./external-command-gateway/:
+ *   types.ts      shared shapes, COMMAND_LOG_PATH, channel +
+ *                 entity-pattern lists
+ *   normalize.ts  message → NormalizedCommand (entity extraction,
+ *                 confidence, approval pre-flag)
+ *   preview.ts    buildOrchestrationPreview (always non-executing)
+ *   log.ts        logCommand + listRecentCommands (file IO)
  *
  * No existing UI, route, or component is modified.
  */
 
-import fs from "fs/promises";
-import path from "path";
 import { randomUUID } from "crypto";
-import { HUB_SHARED_MEMORY_DIR } from "../../utils/repoPaths";
+
+import { TaskExecutionEngine } from "../execution/TaskExecutionEngine";
+import { TaskLifecycleManager } from "../execution/TaskLifecycleManager";
+import { ApprovalWatchdog } from "../approval/ApprovalWatchdog";
 import { logRuntimeEvent } from "../RuntimeLogger";
 
+import { ChannelContextManager, type ChannelType } from "./ChannelContextManager";
+import { logCommand, listRecentCommands } from "./external-command-gateway/log";
+import { normalizeCommand } from "./external-command-gateway/normalize";
+import { buildOrchestrationPreview } from "./external-command-gateway/preview";
 import {
-  TaskExecutionEngine,
-  type TaskExecutionPlan,
-  type TaskType,
-} from "../execution/TaskExecutionEngine";
-import {
-  TaskLifecycleManager,
-  type TaskRecord,
-} from "../execution/TaskLifecycleManager";
-import { ApprovalWatchdog } from "../approval/ApprovalWatchdog";
-import {
-  ToolOrchestrationEngine,
-  type OrchestrationResult,
-  type ToolStep,
-  type ToolType,
-} from "../operational/ToolOrchestrationEngine";
-import {
-  ChannelContextManager,
-  type ChannelType,
-} from "./ChannelContextManager";
+  SUPPORTED_CHANNELS,
+  type CommandLogFile,
+  type ExternalCommandInput,
+  type GatewayResult,
+  type NormalizedCommand,
+} from "./external-command-gateway/types";
 
-const COMMAND_LOG_PATH = path.resolve(
-  HUB_SHARED_MEMORY_DIR,
-  "intake/external-commands.json",
-);
-
-export interface ExternalCommandInput {
-  channel: ChannelType;
-  sender_id: string;
-  message: string;
-  metadata?: Record<string, unknown>;
-  timestamp?: string;
-  /** Optional Zed user_id resolved by the upstream caller. */
-  user_id?: string;
-  /** Optional related conversation in app_chat. */
-  conversation_id?: string | null;
-}
-
-export interface NormalizedCommand {
-  command_id: string;
-  normalized_intent: string;
-  task_type: TaskType;
-  confidence: number;
-  requires_approval: boolean;
-  extracted_entities: Record<string, string>;
-  source_channel: ChannelType;
-}
-
-export interface GatewayResult {
-  command: NormalizedCommand;
-  plan: TaskExecutionPlan;
-  task: TaskRecord;
-  orchestration_preview?: OrchestrationResult;
-}
-
-interface CommandLogFile {
-  version: string;
-  entries: Array<{
-    command_id: string;
-    received_at: string;
-    channel: ChannelType;
-    sender_id: string;
-    user_id: string | null;
-    message_excerpt: string;
-    metadata?: Record<string, unknown>;
-    task_id?: string;
-  }>;
-}
-
-const SUPPORTED_CHANNELS: ChannelType[] = [
-  "app_chat",
-  "voice",
-  "email",
-  "sms",
-  "whatsapp",
-  "webhook",
-  "api",
-  "unknown",
-];
-
-const ENTITY_PATTERNS: Array<{ key: string; regex: RegExp }> = [
-  { key: "email", regex: /[\w.+-]+@[\w-]+\.[\w.-]+/i },
-  { key: "phone", regex: /(?:\+?\d[\d\s().-]{7,}\d)/ },
-  { key: "url", regex: /https?:\/\/[^\s)]+/i },
-  { key: "date", regex: /\b(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4})\b/ },
-  { key: "amount", regex: /\$\s?\d+(?:\.\d{2})?/ },
-];
+export type {
+  ExternalCommandInput,
+  GatewayResult,
+  NormalizedCommand,
+} from "./external-command-gateway/types";
 
 export class ExternalCommandGateway {
   /**
@@ -126,8 +65,10 @@ export class ExternalCommandGateway {
     const user_id = input.user_id || `external:${channel}:${input.sender_id}`;
     const message = (input.message || "").toString();
 
-    // 1. Log the raw command (sanitized excerpt only).
-    await this.logCommand({
+    // 1. Log the raw command (sanitized excerpt only — never the full
+    //    body, which may contain secrets passed from a poorly-built
+    //    upstream client).
+    await logCommand({
       command_id,
       received_at,
       channel,
@@ -137,8 +78,8 @@ export class ExternalCommandGateway {
       metadata: input.metadata,
     });
 
-    // 2. Normalize.
-    const normalized = this.normalize(message, channel, command_id);
+    // 2. Normalize (stateless — see normalize.ts for the heuristics).
+    const normalized = normalizeCommand(message, channel, command_id);
 
     // 3. Build the execution plan (no side effects).
     const plan = TaskExecutionEngine.prepare({
@@ -151,7 +92,8 @@ export class ExternalCommandGateway {
       },
     });
 
-    // 4. Persist as a TaskRecord so the existing pipeline owns lifecycle.
+    // 4. Persist as a TaskRecord so the existing pipeline owns
+    //    lifecycle from here on.
     const task = await TaskLifecycleManager.create({
       user_id,
       conversation_id: input.conversation_id ?? null,
@@ -168,17 +110,15 @@ export class ExternalCommandGateway {
       task_id: task.id,
     });
 
-    // 6. Let the watchdog decide on approval immediately so the caller
-    //    sees the right approval_status when they read the task back.
+    // 6. Let the watchdog decide on approval immediately so the
+    //    caller sees the right approval_status when they read the
+    //    task back.
     await ApprovalWatchdog.evaluate(task);
     const refreshed = (await TaskLifecycleManager.get(task.id)) || task;
 
-    // 7. Build a non-executing orchestration preview so callers can
-    //    show what would happen if the user/admin approves.
-    const orchestration_preview = await this.buildOrchestrationPreview(
-      refreshed,
-      normalized,
-    );
+    // 7. Non-executing orchestration preview so callers can show
+    //    what would happen if the user/admin approves.
+    const orchestration_preview = await buildOrchestrationPreview(refreshed, normalized);
 
     await logRuntimeEvent({
       level: "info",
@@ -202,149 +142,21 @@ export class ExternalCommandGateway {
   }
 
   /**
-   * Stateless normalization — exposed publicly so other modules and
-   * tests can inspect classification without persisting anything.
+   * Stateless normalization — re-exposed on the class so callers
+   * can inspect classification without persisting anything. The
+   * real implementation lives in normalize.ts.
    */
   static normalize(
     message: string,
     channel: ChannelType,
     command_id?: string,
   ): NormalizedCommand {
-    const lower = message.toLowerCase();
-    const task_type: TaskType = /(cancel|terminate|end\b|stop\b)/.test(lower)
-      ? "cancel"
-      : /(book|reserve|schedule|appointment|meeting)/.test(lower)
-        ? "book"
-        : "resolve";
-
-    const extracted_entities = this.extractEntities(message);
-    const confidence = this.estimateConfidence(message, extracted_entities, channel);
-    const normalized_intent = this.summarizeIntent(message, task_type);
-    const requires_approval = this.estimateApproval(lower, task_type);
-
-    return {
-      command_id: command_id || `cmd-${randomUUID()}`,
-      normalized_intent,
-      task_type,
-      confidence,
-      requires_approval,
-      extracted_entities,
-      source_channel: channel,
-    };
+    return normalizeCommand(message, channel, command_id);
   }
 
-  private static extractEntities(message: string): Record<string, string> {
-    const out: Record<string, string> = {};
-    for (const { key, regex } of ENTITY_PATTERNS) {
-      const m = message.match(regex);
-      if (m && m[0]) out[key] = m[0];
-    }
-    return out;
-  }
-
-  private static summarizeIntent(message: string, task_type: TaskType): string {
-    const trimmed = message.replace(/\s+/g, " ").trim().slice(0, 200);
-    return `${task_type}: ${trimmed}`;
-  }
-
-  private static estimateConfidence(
-    message: string,
-    entities: Record<string, string>,
-    channel: ChannelType,
-  ): number {
-    let score = 0.4;
-    if (message.trim().length > 12) score += 0.15;
-    if (Object.keys(entities).length > 0) score += 0.15;
-    if (channel === "app_chat") score += 0.15;
-    if (channel === "api" || channel === "webhook") score += 0.1;
-    if (channel === "unknown") score -= 0.15;
-    return Math.max(0, Math.min(1, Number(score.toFixed(2))));
-  }
-
-  private static estimateApproval(lower: string, task_type: TaskType): boolean {
-    if (task_type === "cancel" || task_type === "book") return true;
-    return /(send|reply|email|message|post|publish|pay|charge|refund|delete|update account)/.test(
-      lower,
-    );
-  }
-
-  private static async buildOrchestrationPreview(
-    task: TaskRecord,
-    normalized: NormalizedCommand,
-  ): Promise<OrchestrationResult> {
-    const steps: ToolStep[] = [];
-
-    if (task.plan.execution_mode === "digital") {
-      const tool: ToolType = normalized.extracted_entities.email ? "email" : "api";
-      steps.push({
-        tool,
-        description: `Prepare ${tool} action from prepared script`,
-        requires_approval: true,
-      });
-    } else if (task.plan.execution_mode === "future_human") {
-      steps.push({
-        tool: "notification",
-        description: "Notify admin queue that a future-human task is pending",
-        requires_approval: true,
-      });
-    } else {
-      steps.push({
-        tool: "notification",
-        description: "Surface the prepared script to the user for manual execution",
-        requires_approval: false,
-      });
-    }
-
-    if (
-      task.approval_status === "admin_required" ||
-      task.approval_status === "user_required" ||
-      task.approval_status === "manual_handling_required"
-    ) {
-      // Approval not yet granted -> orchestration must pause.
-      return ToolOrchestrationEngine.run({
-        task_id: task.id,
-        user_id: task.user_id,
-        steps,
-        approved: false,
-      });
-    }
-
-    // Even when not flagged, never execute as part of intake — preview only.
-    return ToolOrchestrationEngine.run({
-      task_id: task.id,
-      user_id: task.user_id,
-      steps,
-      approved: false,
-    });
-  }
-
-  private static async logCommand(entry: CommandLogFile["entries"][number]): Promise<void> {
-    try {
-      let file: CommandLogFile = { version: "1.0", entries: [] };
-      try {
-        const raw = await fs.readFile(COMMAND_LOG_PATH, "utf-8");
-        const parsed = JSON.parse(raw);
-        if (parsed && Array.isArray(parsed.entries)) file = parsed;
-      } catch {}
-      file.entries.push(entry);
-      await fs.mkdir(path.dirname(COMMAND_LOG_PATH), { recursive: true });
-      await fs.writeFile(COMMAND_LOG_PATH, JSON.stringify(file, null, 2), "utf-8");
-    } catch (err) {
-      console.warn("[ExternalCommandGateway] Failed to write command log:", err);
-    }
-  }
-
+  /** Read the most recent commands, newest first. */
   static async listRecent(limit = 100): Promise<CommandLogFile["entries"]> {
-    try {
-      const raw = await fs.readFile(COMMAND_LOG_PATH, "utf-8");
-      const parsed = JSON.parse(raw);
-      if (parsed && Array.isArray(parsed.entries)) {
-        return (parsed.entries as CommandLogFile["entries"])
-          .slice(-limit)
-          .reverse();
-      }
-    } catch {}
-    return [];
+    return listRecentCommands(limit);
   }
 }
 

--- a/server/services/intake/external-command-gateway/log.ts
+++ b/server/services/intake/external-command-gateway/log.ts
@@ -1,0 +1,45 @@
+import fs from "fs/promises";
+import path from "path";
+
+import { COMMAND_LOG_PATH, type CommandLogFile } from "./types";
+
+/**
+ * Append-only persistent log of every external command we received.
+ * Disk failures are warned, not thrown, because losing one log
+ * entry shouldn't break command intake — the runtime logger still
+ * captures the event independently.
+ */
+export async function logCommand(
+  entry: CommandLogFile["entries"][number],
+): Promise<void> {
+  try {
+    let file: CommandLogFile = { version: "1.0", entries: [] };
+    try {
+      const raw = await fs.readFile(COMMAND_LOG_PATH, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (parsed && Array.isArray(parsed.entries)) file = parsed;
+    } catch {
+      // File doesn't exist yet (first command on this deploy) or is
+      // malformed — fall through with the empty file we set above.
+    }
+    file.entries.push(entry);
+    await fs.mkdir(path.dirname(COMMAND_LOG_PATH), { recursive: true });
+    await fs.writeFile(COMMAND_LOG_PATH, JSON.stringify(file, null, 2), "utf-8");
+  } catch (err) {
+    console.warn("[ExternalCommandGateway] Failed to write command log:", err);
+  }
+}
+
+/** Read the most recent commands, newest first. Used by ops tooling. */
+export async function listRecentCommands(limit = 100): Promise<CommandLogFile["entries"]> {
+  try {
+    const raw = await fs.readFile(COMMAND_LOG_PATH, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && Array.isArray(parsed.entries)) {
+      return (parsed.entries as CommandLogFile["entries"]).slice(-limit).reverse();
+    }
+  } catch {
+    // No log yet, or unreadable → return empty list rather than throwing.
+  }
+  return [];
+}

--- a/server/services/intake/external-command-gateway/normalize.ts
+++ b/server/services/intake/external-command-gateway/normalize.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "crypto";
+
+import type { TaskType } from "../../execution/TaskExecutionEngine";
+import type { ChannelType } from "../ChannelContextManager";
+
+import {
+  ENTITY_PATTERNS,
+  type NormalizedCommand,
+} from "./types";
+
+function extractEntities(message: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const { key, regex } of ENTITY_PATTERNS) {
+    const m = message.match(regex);
+    if (m && m[0]) out[key] = m[0];
+  }
+  return out;
+}
+
+function summarizeIntent(message: string, task_type: TaskType): string {
+  const trimmed = message.replace(/\s+/g, " ").trim().slice(0, 200);
+  return `${task_type}: ${trimmed}`;
+}
+
+/**
+ * Confidence is a rough heuristic, not a calibrated probability:
+ *   - base 0.4
+ *   - + 0.15 for a non-trivial message (>12 chars)
+ *   - + 0.15 if we extracted any entities
+ *   - + 0.15 for in-app chat (highest-signal channel)
+ *   - + 0.10 for api/webhook (typed callers)
+ *   - − 0.15 if we don't know the channel
+ *   - clamped to [0, 1], rounded to 2 decimals
+ */
+function estimateConfidence(
+  message: string,
+  entities: Record<string, string>,
+  channel: ChannelType,
+): number {
+  let score = 0.4;
+  if (message.trim().length > 12) score += 0.15;
+  if (Object.keys(entities).length > 0) score += 0.15;
+  if (channel === "app_chat") score += 0.15;
+  if (channel === "api" || channel === "webhook") score += 0.1;
+  if (channel === "unknown") score -= 0.15;
+  return Math.max(0, Math.min(1, Number(score.toFixed(2))));
+}
+
+/**
+ * Conservative approval gating — cancels and bookings always
+ * require approval; sends, payments, and account mutations also
+ * trip the gate. The ApprovalWatchdog gets the final call; this
+ * is just the gateway's pre-flag.
+ */
+function estimateApproval(lower: string, task_type: TaskType): boolean {
+  if (task_type === "cancel" || task_type === "book") return true;
+  return /(send|reply|email|message|post|publish|pay|charge|refund|delete|update account)/.test(
+    lower,
+  );
+}
+
+/**
+ * Stateless normalization — no persistence, no side effects. Pulls
+ * the task_type from a small set of verb patterns, extracts known
+ * entities, scores confidence, and decides whether the request is
+ * sensitive enough that the gateway should mark it as
+ * requires_approval up front.
+ */
+export function normalizeCommand(
+  message: string,
+  channel: ChannelType,
+  command_id?: string,
+): NormalizedCommand {
+  const lower = message.toLowerCase();
+  const task_type: TaskType = /(cancel|terminate|end\b|stop\b)/.test(lower)
+    ? "cancel"
+    : /(book|reserve|schedule|appointment|meeting)/.test(lower)
+      ? "book"
+      : "resolve";
+
+  const extracted_entities = extractEntities(message);
+  const confidence = estimateConfidence(message, extracted_entities, channel);
+  const normalized_intent = summarizeIntent(message, task_type);
+  const requires_approval = estimateApproval(lower, task_type);
+
+  return {
+    command_id: command_id || `cmd-${randomUUID()}`,
+    normalized_intent,
+    task_type,
+    confidence,
+    requires_approval,
+    extracted_entities,
+    source_channel: channel,
+  };
+}

--- a/server/services/intake/external-command-gateway/preview.ts
+++ b/server/services/intake/external-command-gateway/preview.ts
@@ -1,0 +1,75 @@
+import type { TaskRecord } from "../../execution/TaskLifecycleManager";
+import {
+  ToolOrchestrationEngine,
+  type OrchestrationResult,
+  type ToolStep,
+  type ToolType,
+} from "../../operational/ToolOrchestrationEngine";
+
+import type { NormalizedCommand } from "./types";
+
+/**
+ * Build a non-executing orchestration preview so the caller can
+ * render "here's what would happen if you approve". The steps are
+ * derived from the task's execution_mode:
+ *
+ *   digital       → email if an email entity was found, otherwise api
+ *   future_human  → notification queued for admin review
+ *   default       → notification surfaced to the user for manual run
+ *
+ * Even when no approval is pending, this never executes — we always
+ * pass `approved: false` so the orchestration engine returns the
+ * preview shape without touching any external system.
+ */
+export async function buildOrchestrationPreview(
+  task: TaskRecord,
+  normalized: NormalizedCommand,
+): Promise<OrchestrationResult> {
+  const steps: ToolStep[] = [];
+
+  if (task.plan.execution_mode === "digital") {
+    const tool: ToolType = normalized.extracted_entities.email ? "email" : "api";
+    steps.push({
+      tool,
+      description: `Prepare ${tool} action from prepared script`,
+      requires_approval: true,
+    });
+  } else if (task.plan.execution_mode === "future_human") {
+    steps.push({
+      tool: "notification",
+      description: "Notify admin queue that a future-human task is pending",
+      requires_approval: true,
+    });
+  } else {
+    steps.push({
+      tool: "notification",
+      description: "Surface the prepared script to the user for manual execution",
+      requires_approval: false,
+    });
+  }
+
+  // Approval not yet granted → orchestration must pause. (The
+  // non-approval branch below also passes approved: false because
+  // intake should NEVER execute as a side effect — only the
+  // /api/operational/orchestrate endpoint does that, gated by an
+  // explicit caller-supplied `approved` flag.)
+  if (
+    task.approval_status === "admin_required" ||
+    task.approval_status === "user_required" ||
+    task.approval_status === "manual_handling_required"
+  ) {
+    return ToolOrchestrationEngine.run({
+      task_id: task.id,
+      user_id: task.user_id,
+      steps,
+      approved: false,
+    });
+  }
+
+  return ToolOrchestrationEngine.run({
+    task_id: task.id,
+    user_id: task.user_id,
+    steps,
+    approved: false,
+  });
+}

--- a/server/services/intake/external-command-gateway/types.ts
+++ b/server/services/intake/external-command-gateway/types.ts
@@ -1,0 +1,83 @@
+import path from "path";
+
+import { HUB_SHARED_MEMORY_DIR } from "../../../utils/repoPaths";
+import type {
+  TaskExecutionPlan,
+  TaskType,
+} from "../../execution/TaskExecutionEngine";
+import type { TaskRecord } from "../../execution/TaskLifecycleManager";
+import type { OrchestrationResult } from "../../operational/ToolOrchestrationEngine";
+import type { ChannelType } from "../ChannelContextManager";
+
+export const COMMAND_LOG_PATH = path.resolve(
+  HUB_SHARED_MEMORY_DIR,
+  "intake/external-commands.json",
+);
+
+export interface ExternalCommandInput {
+  channel: ChannelType;
+  sender_id: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+  timestamp?: string;
+  /** Optional Zed user_id resolved by the upstream caller. */
+  user_id?: string;
+  /** Optional related conversation in app_chat. */
+  conversation_id?: string | null;
+}
+
+export interface NormalizedCommand {
+  command_id: string;
+  normalized_intent: string;
+  task_type: TaskType;
+  confidence: number;
+  requires_approval: boolean;
+  extracted_entities: Record<string, string>;
+  source_channel: ChannelType;
+}
+
+export interface GatewayResult {
+  command: NormalizedCommand;
+  plan: TaskExecutionPlan;
+  task: TaskRecord;
+  orchestration_preview?: OrchestrationResult;
+}
+
+export interface CommandLogFile {
+  version: string;
+  entries: Array<{
+    command_id: string;
+    received_at: string;
+    channel: ChannelType;
+    sender_id: string;
+    user_id: string | null;
+    message_excerpt: string;
+    metadata?: Record<string, unknown>;
+    task_id?: string;
+  }>;
+}
+
+export const SUPPORTED_CHANNELS: ChannelType[] = [
+  "app_chat",
+  "voice",
+  "email",
+  "sms",
+  "whatsapp",
+  "webhook",
+  "api",
+  "unknown",
+];
+
+/**
+ * Entity sniffers used during normalization. First-match wins per
+ * key; the order is roughly "most specific first" so e.g. an email
+ * captures the @-pattern before a phone regex tries to interpret
+ * the digits in a number-bearing email address.
+ */
+export const ENTITY_PATTERNS: Array<{ key: string; regex: RegExp }> = [
+  { key: "email", regex: /[\w.+-]+@[\w-]+\.[\w.-]+/i },
+  { key: "phone", regex: /(?:\+?\d[\d\s().-]{7,}\d)/ },
+  { key: "url", regex: /https?:\/\/[^\s)]+/i },
+  { key: "date", regex: /\b(\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{2,4})\b/ },
+  { key: "amount", regex: /\$\s?\d+(?:\.\d{2})?/ },
+];


### PR DESCRIPTION
Splits the 351-line `ExternalCommandGateway.ts` into the class shell + four focused helpers. All 5 internal callers (`VoiceCommandBridge`, `MessagingBridge`, `registerIntakeRoutes`) keep working unchanged — the static methods `receive`, `normalize`, `listRecent` are preserved on the class.

## Files

| File | Lines | Purpose |
| --- | --- | --- |
| `services/intake/ExternalCommandGateway.ts` | 163 | Class — `receive()` orchestration, thin `normalize` + `listRecent` re-exports |
| `services/intake/external-command-gateway/types.ts` | 83 | `ExternalCommandInput` / `NormalizedCommand` / `GatewayResult` / `CommandLogFile`, `COMMAND_LOG_PATH`, `SUPPORTED_CHANNELS`, `ENTITY_PATTERNS` (with note on first-match ordering) |
| `services/intake/external-command-gateway/normalize.ts` | 95 | `normalizeCommand` + `extractEntities` + `summarizeIntent` + `estimateConfidence` (jsdoc explains the per-channel score deltas) + `estimateApproval` (conservative gating policy) |
| `services/intake/external-command-gateway/preview.ts` | 75 | `buildOrchestrationPreview` — always non-executing, comment explains why both branches pass `approved: false` (intake is never allowed to execute as a side effect) |
| `services/intake/external-command-gateway/log.ts` | 45 | `logCommand` + `listRecentCommands` — append-only JSON with disk-failure-warned-not-thrown semantics |

## Notes

- **No behavior change.** Same `receive()` pipeline order, same approval pre-flag, same orchestration preview semantics, same log shape.
- The class file is the orchestration narrative; each step has a comment about what it does and why. The actual mechanics (heuristics, file IO, preview shape) live in the helpers where a reader chasing one of those concerns can read just that file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnJ7jUBn6j9ZX1AxXkHdJS)_